### PR TITLE
Problem: Redundant transitive dependencies

### DIFF
--- a/racket2nix
+++ b/racket2nix
@@ -173,9 +173,10 @@ EOM
   ; racket may or may not be in here
   (define dependency-names (remove* '("racket") dep-names))
   (define trans-dep-names
-    (append*
+    (remove-duplicates
+     (append*
       (for/list ((name dependency-names))
-        (name->transitive-dependency-names name package-dictionary))))
+        (name->transitive-dependency-names name package-dictionary)))))
   (derivation name url sha1 trans-dep-names))
 
 (define (name->let-deps-and-reference package-name (package-dictionary (make-hash)))


### PR DESCRIPTION
Solution: Remove duplicates in package->derivation, not just in
package->transitive-dependency-names.

Closes #14