### PR TITLE
Problem: Exception constructed incorrectly

### DIFF
--- a/racket2nix
+++ b/racket2nix
@@ -121,7 +121,9 @@ EOM
 
 (define (name->transitive-dependency-names package-name package-dictionary (breadcrumbs '()))
   (when (member package-name breadcrumbs)
-    (raise (make-exn:fail:contract "Circular dependencies are supposed to be culled.")))
+    (raise-argument-error 'name->transitive-dependency-names
+                          "not supposed to be a circular dependency"
+                          0 package-name breadcrumbs))
 
   (define package (memo-lookup-package package-dictionary package-name))
 


### PR DESCRIPTION
When the erroneous condition would occur (tested with intentionally
faulty code), the exception contructor would be called incorrectly:

exn:fail:contract: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 2
  given: 1
  arguments...:
   "Circular dependencies are supposed to be culled."

Solution: Use the convenience function instead, and supply better
arguments.

The correct exception (which never happens):

name->transitive-dependency-names: contract violation
  expected: not supposed to be a circular dependency
  given: "racket-doc"
  argument position: 1st
  other arguments...:
   '("rackunit-doc" "racket-doc" "drracket")