### PR TITLE
Problem: circularBuildInputs makes our builds circular

### DIFF
--- a/racket2nix
+++ b/racket2nix
@@ -75,7 +75,7 @@ EOM
   (define circular-build-inputs
     (string-join
       (for/list ((name circular-dependency-names))
-        (format "_~a" name))))
+        (format "\"~a\"" name))))
   (define link-dirs
     (string-join
       (for/list ((name dependency-names))


### PR DESCRIPTION
Solution: Use strings, not variable references.

