### PR TITLE
Circular builds redux

### DIFF
--- a/racket2nix
+++ b/racket2nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     echo ${racket-cmd}
 
     # install and link us
-    if ${racket-cmd} -e "(require pkg/lib) (exit (if (member \"$name\" (installed-pkg-names #:scope (bytes->path (string->bytes/utf-8 \"${_racket-lib.out}/share/racket/pkgs\")))) 0 1))"; then
+    if ${racket-cmd} -e "(require pkg/lib) (exit (if (member \"$name\" (installed-pkg-names #:scope (bytes->path (string->bytes/utf-8 \"${_racket-lib.out}/share/racket/pkgs\")))) 1 0))"; then
       ${raco} pkg install --no-setup --copy --deps fail --fail-fast --scope installation ./$name
     fi
   '';

--- a/racket2nix
+++ b/racket2nix
@@ -55,6 +55,12 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/etc/racket $out/share/racket
     sed -e 's|$out|'"$out|g" > $out/etc/racket/config.rktd < $racketConfigPath
+
+    remove_deps="${stdenv.lib.concatStringsSep " " circularBuildInputs}"
+    if [[ -n $remove_deps ]]; then
+      sed -i $(printf -- '-e s/"%s"//g ' $remove_deps) $name/info.rkt
+    fi
+
     echo ${racket-cmd}
 
     # install and link us


### PR DESCRIPTION
    Problem: Skipping circular dependencies breaks install
    
    When we simply do not install a circular dependency, the dependant
    fails to install due to the missing dependency.
    
    Solution: Remove the dependencies inside the packages when installing.
    
    We go inside the info.rkt and remove all references to the circular
    dependency.
    
    This works for the test set of racket-doc with transitive
    dependencies.
    
    drracket builds again, and this time it's not empty. It's not complete
    though, that's for issue #23.
    
    Closes #19
