### PR TITLE
Problem: template text invalid format string, missing apostrophe

### DIFF
--- a/racket2nix
+++ b/racket2nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     if ! ulimit -n $maxFileDescriptors; then
-      echo >&2 If the number of allowed file descriptors is lower than ~2048,'
+      echo >&2 If the number of allowed file descriptors is lower than ~~2048,'
       echo >&2 packages like drracket or racket-doc will not build correctly.
       echo >&2 If raising the soft limit fails '(like it just did)', you will
       echo >&2 have to raise the hard limit on your operating system.

--- a/racket2nix
+++ b/racket2nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     if ! ulimit -n $maxFileDescriptors; then
-      echo >&2 If the number of allowed file descriptors is lower than ~~2048,'
+      echo >&2 If the number of allowed file descriptors is lower than '~~2048,'
       echo >&2 packages like drracket or racket-doc will not build correctly.
       echo >&2 If raising the soft limit fails '(like it just did)', you will
       echo >&2 have to raise the hard limit on your operating system.


### PR DESCRIPTION
Solution: Escape the tilde in '~2048', add missing apostrophe.

Closes #37.