### PR TITLE
Problem: No automated testing

### DIFF
--- a/generate-default.nix
+++ b/generate-default.nix
@@ -1,0 +1,28 @@
+{ pkgs ? import <nixpkgs> { }
+, stdenvNoCC ? pkgs.stdenvNoCC
+, racket ? pkgs.racket-minimal
+, racket2nix ? pkgs.callPackage ./. { inherit racket; }
+, cacert ? pkgs.cacert
+, racket-catalog ? stdenvNoCC.mkDerivation {
+    name = "pkgs-all";
+    buildInputs = [ racket ];
+    builder = builtins.toFile "dump-catalogs.sh" ''
+      $racket/bin/racket -N dump-catalogs $racket2nix/share/racket/pkgs/nix/dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
+    '';
+    inherit racket racket2nix;
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+    outputHashMode = "flat";
+    outputHashAlgo = "sha256";
+    outputHash = "1p8f4yrnv9ny135a41brxh7k740aiz6m41l67bz8ap1rlq2x7pgm";
+  }
+}:
+
+(stdenvNoCC.mkDerivation rec {
+  name = "racket2nix-default.nix";
+  src = ./.;
+  buildInputs = [ racket racket2nix ];
+  phases = "unpackPhase installPhase";
+  installPhase = ''
+    racket -G ${racket2nix}/etc/racket -l- nix/racket2nix --catalog ${racket-catalog} --catalog pkgs-nix nix > $out
+  '';
+}) // { inherit racket-catalog; }

--- a/pkgs-nix
+++ b/pkgs-nix
@@ -1,0 +1,3 @@
+#hash(
+("nix" . #hash((author . "claes.wallin@greatsinodevelopment.com") (checksum . "") (dependencies . ("base")) (description . "Creates Nix derivations for Racket packages and their dependencies.") (modules . ((lib "nix/dump-catalogs.rkt") (lib "nix/racket2nix.rkt"))) (name . "nix") (source . "nix") (tags . ())))
+)

--- a/test.nix
+++ b/test.nix
@@ -1,0 +1,26 @@
+let
+  bootPkgs = import <nixpkgs> { };
+  bootFetchgit = bootPkgs.fetchgit;
+  remotePkgs = bootFetchgit {
+    url = "git://github.com/NixOS/nixpkgs-channels.git";
+    rev = "a66ce38acea505c4b3bfac9806669d2ad8b34efa";
+    sha256 = "1jrz6lkhx64mvm0h4gky9b6iaazivq69smppkx33hmrm4553dx5h";
+  };
+in
+{ pkgs ? import remotePkgs { }
+, stdenvNoCC ? pkgs.stdenvNoCC
+, racket ? pkgs.racket-minimal
+, default-nix ? pkgs.callPackage ./generate-default.nix { inherit racket; }
+, colordiff ? pkgs.colordiff
+}:
+
+stdenvNoCC.mkDerivation rec {
+  name = "test-racket2nix";
+  src = ./.;
+  phases = "unpackPhase buildPhase";
+  buildPhase = ''
+    echo output in $out
+    echo
+    diff -u default.nix ${default-nix} | tee $out | ${colordiff}/bin/colordiff
+  '';
+}


### PR DESCRIPTION
Solution: Create a nix derivation that depends on generation of our
default.nix and verifies that it didn't change.

It's not yet correct, because our default.nix is ahead of what
racket2nix can generate, but it's a great tool for getting us there.