### PR TITLE
Problem: dump-catalogs is missing

### DIFF
--- a/nix/dump-catalogs.rkt
+++ b/nix/dump-catalogs.rkt
@@ -1,0 +1,11 @@
+#lang racket
+
+(require net/url-string)
+(require pkg/lib)
+(require (prefix-in pkg-private: pkg/private/params))
+
+(command-line
+  #:args catalogs
+  (begin
+    (pkg-private:current-pkg-catalogs (map string->url catalogs))
+    (write (get-all-pkg-details-from-catalogs))))


### PR DESCRIPTION
As it is used by a fixed-output derivation, I never noticed that I
only had it locally, even when trying in a fresh worktree.

Solution: Add dump-catalogs.