### PR TITLE
Problem: We cannot create expressions directly from directories

### DIFF
--- a/pkgs-nix
+++ b/pkgs-nix
@@ -1,3 +1,0 @@
-#hash(
-("nix" . #hash((author . "claes.wallin@greatsinodevelopment.com") (checksum . "") (dependencies . ("base")) (description . "Creates Nix derivations for Racket packages and their dependencies.") (modules . ((lib "nix/dump-catalogs.rkt") (lib "nix/racket2nix.rkt"))) (name . "nix") (source . "nix") (tags . ())))
-)

--- a/update-default.nix
+++ b/update-default.nix
@@ -23,6 +23,6 @@
   buildInputs = [ racket racket2nix ];
   phases = "unpackPhase installPhase";
   installPhase = ''
-    racket -G ${racket2nix}/etc/racket -l- nix/racket2nix --catalog ${racket-catalog} --catalog pkgs-nix nix > $out
+    racket -G ${racket2nix}/etc/racket -l- nix/racket2nix --catalog ${racket-catalog} ./nix > $out
   '';
 }) // { inherit racket-catalog; }


### PR DESCRIPTION
We need packages to be present in our catalogs in order to process them.

Solution: If package name contains at least one slash, treat it as a directory.

Synthesize a package entry from the directory.

Use this mechanism to package ./nix.

Closes #3
Closes #4