### PR TITLE
Problem: Makefile requires a pkgs-nix file that is no longer there

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: all
 
 all: default.nix
 
-RACKET2NIX_FILES=update-default.nix nix/info.rkt nix/racket2nix.rkt pkgs-nix
+RACKET2NIX_FILES=update-default.nix nix/info.rkt nix/racket2nix.rkt
 
 default.nix.in.timestamp: $(RACKET2NIX_FILES)
 	nix-build update-default.nix --out-link default.nix.in

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -17,3 +17,8 @@ make test | awk '
   }
   { print }
 '
+
+## `make` needs to come after `make test`, otherwise it fixes one
+## divergence `make test` is supposed to detect.
+
+make


### PR DESCRIPTION
Solution: Remove pkgs-nix dependency from Makefile

Add plain make to test sequence to prevent this from happening again.