### PR TITLE
Problem: `make` doesn't test that self-hosted racket2nix works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ default.nix.in.timestamp: $(RACKET2NIX_FILES)
 
 default.nix: default.nix.in.timestamp
 	cat < default.nix.in > $@.new
-	nix-build $@.new
 	mv $@.new $@
 
 pkgs-all:

--- a/update-default.nix
+++ b/update-default.nix
@@ -1,28 +1,45 @@
 { pkgs ? import <nixpkgs> { }
 , stdenvNoCC ? pkgs.stdenvNoCC
 , racket ? pkgs.racket-minimal
-, racket2nix ? pkgs.callPackage ./. { inherit racket; }
 , cacert ? pkgs.cacert
-, racket-catalog ? stdenvNoCC.mkDerivation {
+}:
+
+let attrs = rec {
+  racket-catalog = stdenvNoCC.mkDerivation {
     name = "pkgs-all";
+    src = ./.;
     buildInputs = [ racket ];
-    builder = builtins.toFile "dump-catalogs.sh" ''
-      $racket/bin/racket -N dump-catalogs $racket2nix/share/racket/pkgs/nix/dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
+    phases = "unpackPhase installPhase";
+    installPhase = ''
+      $racket/bin/racket -N dump-catalogs ./nix/dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
     '';
-    inherit racket racket2nix;
+    inherit racket;
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     outputHashMode = "flat";
     outputHashAlgo = "sha256";
     outputHash = "1p8f4yrnv9ny135a41brxh7k740aiz6m41l67bz8ap1rlq2x7pgm";
-  }
-}:
-
-(stdenvNoCC.mkDerivation rec {
-  name = "racket2nix-default.nix";
-  src = ./.;
-  buildInputs = [ racket racket2nix ];
-  phases = "unpackPhase installPhase";
-  installPhase = ''
-    racket -G ${racket2nix}/etc/racket -l- nix/racket2nix --catalog ${racket-catalog} ./nix > $out
-  '';
-}) // { inherit racket-catalog; }
+  };
+  default-nix-stage0 = stdenvNoCC.mkDerivation {
+    name = "racket2nix-stage0.nix";
+    src = ./.;
+    buildInputs = [ racket ];
+    phases = "unpackPhase installPhase";
+    installPhase = ''
+      racket -N racket2nix ./nix/racket2nix.rkt --catalog ${racket-catalog} ./nix > $out
+    '';
+  };
+  racket2nix-stage0 = (pkgs.callPackage default-nix-stage0 { inherit racket; }).overrideDerivation (drv: rec { src = ./nix; srcs = [ src ]; });
+  default-nix = stdenvNoCC.mkDerivation {
+    name = "racket2nix.nix";
+    src = ./.;
+    buildInputs = [ racket ];
+    phases = "unpackPhase installPhase";
+    installPhase = ''
+      racket -G ${racket2nix-stage0}/etc/racket -N racket2nix -l- nix/racket2nix --catalog ${racket-catalog} ./nix > $out
+      diff ${default-nix-stage0} $out
+    '';
+  };
+  racket2nix = (pkgs.callPackage default-nix { inherit racket; }).overrideDerivation (drv: rec { src = ./nix; srcs = [ src ]; });
+};
+in
+attrs.default-nix // attrs


### PR DESCRIPTION
We would still catch it in Travis when we build racket-doc, but better
to catch it early.

Solution: Use an unpackaged racket2nix to create a default.nix, make a
new racket2nix from that, run again, compare outputs.

This replaces and improves the test in Makefile (you would have to run
the original `make` twice to get the equivalent), so we can lift that
out. If nix-build returns something, it's tested.