### PR TITLE
Problem: launchers aren't getting created

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,10 +32,10 @@ let attrs = rec {
   racket2nix-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix.nix";
     src = ./.;
-    buildInputs = [ racket ];
+    buildInputs = [ racket2nix-stage0 ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket -G ${racket2nix-stage0}/etc/racket -N racket2nix -l- nix/racket2nix --catalog ${racket-catalog} ./nix > $out
+      racket2nix --catalog ${racket-catalog} ./nix > $out
       diff ${racket2nix-stage0-nix} $out
     '';
   };

--- a/test.nix
+++ b/test.nix
@@ -19,10 +19,10 @@ let attrs = rec {
   inherit racket2nix;
   racket-doc-nix = stdenvNoCC.mkDerivation {
     name = "racket-doc.nix";
-    buildInputs = [ racket ];
+    buildInputs = [ racket2nix ];
     phases = "installPhase";
     installPhase = ''
-      racket -G ${racket2nix}/etc/racket -l- nix/racket2nix --catalog ${racket-catalog} racket-doc > $out
+      racket2nix --catalog ${racket-catalog} racket-doc > $out
     '';
   };
   racket-doc = pkgs.callPackage racket-doc-nix { inherit racket; };


### PR DESCRIPTION
Solution: adapt config.rktd, create a racket wrapper, fake a lib-dir

The real solution is to patch racket to use search paths for lib and bin.

Our solution here is polluting bin so that a user can't trivially
install a racket2nix-generated derivation along with racket or
another generated derivation.

See #66 for more on filename pollution.

Closes #41 