### PR TITLE
Problem: cannot reach attrs in default.nix without building racket2nix-nix

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> { }
+, stdenvNoCC ? pkgs.stdenvNoCC
+, racket ? pkgs.racket-minimal
+, cacert ? pkgs.cacert
+}:
+
+stdenvNoCC.mkDerivation {
+  name = "pkgs-all";
+  src = ./.;
+  buildInputs = [ racket ];
+  phases = "unpackPhase installPhase";
+  installPhase = ''
+    $racket/bin/racket -N dump-catalogs ./nix/dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
+  '';
+  inherit racket;
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  outputHashMode = "flat";
+  outputHashAlgo = "sha256";
+  outputHash = "1p8f4yrnv9ny135a41brxh7k740aiz6m41l67bz8ap1rlq2x7pgm";
+}

--- a/default.nix
+++ b/default.nix
@@ -2,33 +2,12 @@
 , stdenvNoCC ? pkgs.stdenvNoCC
 , racket ? pkgs.racket-minimal
 , cacert ? pkgs.cacert
+, racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
+, racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
+, racket2nix-stage0-nix ? racket2nix-stage0.racket2nix-stage0-nix
 }:
 
 let attrs = rec {
-  racket-catalog = stdenvNoCC.mkDerivation {
-    name = "pkgs-all";
-    src = ./.;
-    buildInputs = [ racket ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      $racket/bin/racket -N dump-catalogs ./nix/dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
-    '';
-    inherit racket;
-    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-    outputHashMode = "flat";
-    outputHashAlgo = "sha256";
-    outputHash = "1p8f4yrnv9ny135a41brxh7k740aiz6m41l67bz8ap1rlq2x7pgm";
-  };
-  racket2nix-stage0-nix = stdenvNoCC.mkDerivation {
-    name = "racket2nix-stage0.nix";
-    src = ./.;
-    buildInputs = [ racket ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      racket -N racket2nix ./nix/racket2nix.rkt --catalog ${racket-catalog} ./nix > $out
-    '';
-  };
-  racket2nix-stage0 = (pkgs.callPackage racket2nix-stage0-nix { inherit racket; }).overrideDerivation (drv: rec { src = ./nix; srcs = [ src ]; });
   racket2nix-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix.nix";
     src = ./.;

--- a/stage0.nix
+++ b/stage0.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> { }
+, stdenvNoCC ? pkgs.stdenvNoCC
+, racket ? pkgs.racket-minimal
+, racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
+}:
+
+let attrs = rec {
+  racket2nix-stage0-nix = stdenvNoCC.mkDerivation {
+    name = "racket2nix-stage0.nix";
+    src = ./.;
+    buildInputs = [ racket ];
+    phases = "unpackPhase installPhase";
+    installPhase = ''
+      racket -N racket2nix ./nix/racket2nix.rkt --catalog ${racket-catalog} ./nix > $out
+    '';
+  };
+  racket2nix-stage0 = (pkgs.callPackage racket2nix-stage0-nix { inherit racket; }).overrideDerivation (drv: rec { src = ./nix; srcs = [ src ]; });
+};
+in
+attrs.racket2nix-stage0 // attrs

--- a/test.nix
+++ b/test.nix
@@ -11,9 +11,9 @@ in
 , stdenvNoCC ? pkgs.stdenvNoCC
 , racket ? pkgs.racket-minimal
 , racket2nix ? pkgs.callPackage ./. { inherit racket; }
-, racket2nix-stage0 ? racket2nix.racket2nix-stage0
+, racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
 , colordiff ? pkgs.colordiff
-, racket-catalog ? racket2nix.racket-catalog
+, racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
 }:
 
 let attrs = rec {

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -3,14 +3,12 @@ set -e
 set -u
 
 printf 'travis_fold:start:racket2nix-stage0.prerequisites\r'
-nix-shell test.nix -A racket2nix-stage0 --run true
+nix-shell stage0.nix --run true
 printf 'travis_fold:end:racket2nix-stage0.prerequisites\r'
 
 printf 'travis_fold:start:racket2nix\r'
-nix-build test.nix -A racket2nix
-printf 'travis_fold:end:racket2nix\r'
-
 make
+printf 'travis_fold:end:racket2nix\r'
 
 make test | awk '
   BEGIN {


### PR DESCRIPTION


For nix to know whether `racket2nix // attrs` is allowed or not, it needs to
build `racket2nix-nix` so it can evaluate `racket2nix`. This is confusing and
stops e.g. pre-fetching from being exactly what it looks like.

Solution: Split out stage0.nix and catalog.nix