### PR TITLE
Problem: Travis still failing to fail

### DIFF
--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 set -e
 set -u
+set -o pipefail
 
 printf 'travis_fold:start:racket2nix-stage0.prerequisites\r'
 nix-shell test.nix -A racket2nix-stage0 --run true


### PR DESCRIPTION
The pipe to awk makes awk's the only exit code considered within that
pipe.

Solution: Set 'pipefail'.

If this change fails, it was successful. Now let's fix that
deinprogramm issue and make success mean success.