### PR TITLE
Problem: we may accidentally install old code

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -68,6 +68,7 @@ let mkRacketDerivation = lib.makeOverridable (attrs: stdenv.mkDerivation (rec {
       fi
     done
     chmod u+w -R .
+    find . -name '*.zo' -delete
     runHook postUnpack
   '';
 


### PR DESCRIPTION
This just happened locally when bootstrapping racket2nix. Took me
hours of looking for faults in the wrong place.

Solution: Remove all *.zo before installing.