### PR TITLE
Problem: src = ./. is too wide

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation {
   name = "pkgs-all";
-  src = ./.;
+  src = ./nix;
   buildInputs = [ racket ];
   phases = "unpackPhase installPhase";
   installPhase = ''
-    $racket/bin/racket -N dump-catalogs ./nix/dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
+    $racket/bin/racket -N dump-catalogs ./dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
   '';
   inherit racket;
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/default.nix
+++ b/default.nix
@@ -10,11 +10,11 @@
 let attrs = rec {
   racket2nix-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix.nix";
-    src = ./.;
+    src = ./nix;
     buildInputs = [ racket2nix-stage0 ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket2nix --catalog ${racket-catalog} ./nix > $out
+      racket2nix --catalog ${racket-catalog} ../nix > $out
       diff ${racket2nix-stage0-nix} $out
     '';
   };

--- a/stage0.nix
+++ b/stage0.nix
@@ -7,11 +7,11 @@
 let attrs = rec {
   racket2nix-stage0-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix-stage0.nix";
-    src = ./.;
+    src = ./nix;
     buildInputs = [ racket ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket -N racket2nix ./nix/racket2nix.rkt --catalog ${racket-catalog} ./nix > $out
+      racket -N racket2nix ./racket2nix.rkt --catalog ${racket-catalog} ../nix > $out
     '';
   };
   racket2nix-stage0 = (pkgs.callPackage racket2nix-stage0-nix { inherit racket; }).overrideDerivation (drv: rec { src = ./nix; srcs = [ src ]; });


### PR DESCRIPTION
We actually never use anything outside ./nix for our derivations, and
capturing all of ./.  means you get spurious builds just because you
happened to have a temporary file or a ./result link in there.

Solution: Change racket-catalog, racket2nix-stage0 and racket2nix to build from ./nix instead.