### PR TITLE
Problem: We have a hard-coded assumption in the skip-install code

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -17,6 +17,7 @@ in
 }:
 
 let attrs = rec {
+  inherit pkgs;
   inherit racket2nix;
   inherit racket2nix-stage0;
   racket-doc-nix = stdenvNoCC.mkDerivation {

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -10,3 +10,17 @@ printf 'travis_fold:end:racket2nix-stage0.prerequisites\r'
 printf 'travis_fold:start:racket2nix\r'
 make
 printf 'travis_fold:end:racket2nix\r'
+
+## We need to build racket-doc-nix for (test.nix).pkgs below to be
+## resolvable
+printf 'travis_fold:start:racket-doc-nix\r'
+nix-build --no-out-link test.nix -A racket-doc-nix
+printf 'travis_fold:end:racket-doc-nix\r'
+
+# Allow running travis-test.sh on macOS while full racket is not yet available
+if (( $(nix-instantiate --eval -E 'with (import ./test.nix {}).pkgs;
+          if (builtins.elem builtins.currentSystem racket.meta.platforms) then 1 else 0') )); then
+  printf 'travis_fold:start:racket2nix.full-racket\r'
+    nix-build --no-out-link -E 'with (import ./test.nix {}).pkgs; callPackage ./. {}'
+  printf 'travis_fold:end:racket2nix.full-racket\r'
+fi


### PR DESCRIPTION
Solution: Instead of hard-coding that we expect any unexpected
packages to be in the racket-lib (racket) derivation, ask the runtime
what scopes there are.

Also, check per package to install, not for all packages based on what
package our name says we are mainly packaging.

travis-test.sh: Verify that racket2nix builds against full racket
too.