### PR TITLE
Problem: make pkgs-all stopped working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ racket2nix:
 	nix-build --no-out-link
 
 pkgs-all:
-	nix-build --out-link pkgs-all -A racket-catalog
+	nix-build --out-link pkgs-all catalog.nix
 
 test:
 	nix-shell test.nix --run true 2>&1

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -3,6 +3,10 @@ set -e
 set -u
 set -o pipefail
 
+printf 'travis_fold:start:catalog\r'
+make pkgs-all
+printf 'travis_fold:end:catalog\r'
+
 printf 'travis_fold:start:racket2nix-stage0.prerequisites\r'
 nix-shell stage0.nix --run true
 printf 'travis_fold:end:racket2nix-stage0.prerequisites\r'


### PR DESCRIPTION
When we extracted catalog.nix we forgot to update Makefile.

Solution: Make Makefile refer to catalog.nix instead of the non-existent racket-catalog attribute.

Add 'make pkgs-all' to travis-test.sh.