### PR TITLE
Problem: unnecessary code in dump-catalogs

### DIFF
--- a/nix/dump-catalogs.rkt
+++ b/nix/dump-catalogs.rkt
@@ -6,6 +6,5 @@
 
 (command-line
   #:args catalogs
-  (begin
-    (pkg-private:current-pkg-catalogs (map string->url catalogs))
-    (write (get-all-pkg-details-from-catalogs))))
+  (pkg-private:current-pkg-catalogs (map string->url catalogs))
+  (write (get-all-pkg-details-from-catalogs)))


### PR DESCRIPTION
The begin is implied in command-line after #:args.

Solution: Remove the begin in dump-catalogs.