### PR TITLE
Problem: darwin cannot build drracket (PR nixpkgs#35429)

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { }
 , stdenvNoCC ? pkgs.stdenvNoCC
-, racket ? pkgs.racket-minimal
+, racket ? pkgs.callPackage ./racket-minimal.nix {}
 , cacert ? pkgs.cacert
 }:
 

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { }
 , stdenvNoCC ? pkgs.stdenvNoCC
-, racket ? pkgs.racket-minimal
+, racket ? pkgs.callPackage ./racket-minimal.nix {}
 , cacert ? pkgs.cacert
 , racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }

--- a/racket-minimal.nix
+++ b/racket-minimal.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <stdenv> {}
+, stdenv ? pkgs.stdenv
+, libiconv ? pkgs.libiconv
+}:
+
+if stdenv.isDarwin then
+  pkgs.racket-minimal.overrideDerivation (drv: {
+    buildInputs = drv.buildInputs ++ [ libiconv ];
+  })
+else
+pkgs.racket-minimal

--- a/stage0.nix
+++ b/stage0.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { }
 , stdenvNoCC ? pkgs.stdenvNoCC
-, racket ? pkgs.racket-minimal
+, racket ? pkgs.callPackage ./racket-minimal.nix {}
 , racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
 }:
 

--- a/test.nix
+++ b/test.nix
@@ -9,7 +9,7 @@ let
 in
 { pkgs ? import remotePkgs { }
 , stdenvNoCC ? pkgs.stdenvNoCC
-, racket ? pkgs.racket-minimal
+, racket ? pkgs.callPackage ./racket-minimal.nix {}
 , racket2nix ? pkgs.callPackage ./. { inherit racket; }
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
 , colordiff ? pkgs.colordiff


### PR DESCRIPTION
The system libiconv doesn't support UTF-16, which is used in one of
the code examples in the documentation.

Solution: On darwin, override racket-minimal to use GNU libiconv

Put the racket-minimal override in its own file and import
everywhere.