### PR TITLE
Problem: our Travis folds are too spammy

### DIFF
--- a/travis-test.sh
+++ b/travis-test.sh
@@ -3,28 +3,44 @@ set -e
 set -u
 set -o pipefail
 
-printf 'travis_fold:start:catalog\r'
-make pkgs-all
-printf 'travis_fold:end:catalog\r'
+function subfold() {
+  local prefix=$1
+  awk '
+    BEGIN {
+      current_scope="'$prefix'"
+      printf "travis_fold:start:%s\r", current_scope
+    }
+    /^building \x27\/nix\/store\/.*[.]drv\x27/ {
+      if(current_scope != "") {
+        printf "travis_fold:end:%s\r", current_scope
+      }
+      current_scope=$0
+      sub("building \x27/nix/store/", "", current_scope)
+      sub("\x27.*", "", current_scope)
+      current_scope=current_scope ".." "'$prefix'"
+      printf "travis_fold:start:%s\r", current_scope
+    }
+    { print }
+    END {
+      if(current_scope != "") {
+        printf "travis_fold:end:%s\r", current_scope
+      }
+    }
+  '
+}
 
-printf 'travis_fold:start:racket2nix-stage0.prerequisites\r'
-nix-shell stage0.nix --run true
-printf 'travis_fold:end:racket2nix-stage0.prerequisites\r'
+make pkgs-all |& subfold catalog
 
-printf 'travis_fold:start:racket2nix\r'
-make
-printf 'travis_fold:end:racket2nix\r'
+nix-shell stage0.nix --run true |& subfold racket2nix-stage0.prerequisites
+
+make |& subfold racket2nix
 
 ## We need to build racket-doc-nix for (test.nix).pkgs below to be
 ## resolvable
-printf 'travis_fold:start:racket-doc-nix\r'
-nix-build --no-out-link test.nix -A racket-doc-nix
-printf 'travis_fold:end:racket-doc-nix\r'
+nix-build --no-out-link test.nix -A racket-doc-nix |& subfold racket-doc-nix
 
 # Allow running travis-test.sh on macOS while full racket is not yet available
 if (( $(nix-instantiate --eval -E 'with (import ./test.nix {}).pkgs;
           if (builtins.elem builtins.currentSystem racket.meta.platforms) then 1 else 0') )); then
-  printf 'travis_fold:start:racket2nix.full-racket\r'
-    nix-build --no-out-link -E 'with (import ./test.nix {}).pkgs; callPackage ./. {}'
-  printf 'travis_fold:end:racket2nix.full-racket\r'
+  nix-build --no-out-link -E 'with (import ./test.nix {}).pkgs; callPackage ./. {}' |& subfold racket2nix.full-racket
 fi


### PR DESCRIPTION
racket2nix now has dependencies, and the folds we have are too coarse.

Solution: Bring back the derivation folds filter, and apply it within
each major fold to produce sub-folds.

Travis doesn't actually have sub-folds, so let's emulate them.

The most interesting folds are the last of the
..-nix.drv..racket2nix and ..-nix.drv..racket2nix.full-racket folds,
because that's where the tests run. Maybe we should highlight that
somehow, but if the tests fail it becomes unfolded and obvious, so
it's not a priority for now.