### PR TITLE
Problem: no trivial way to put racket2nix in your PATH

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,6 +52,11 @@ let attrs = rec {
     '';
   };
   racket2nix-flat-nix = racket2nix-flat-stage1-nix;
+  racket2nix-env = stdenvNoCC.mkDerivation {
+    phases = [];
+    buildInputs = [ racket2nix ];
+    name = "racket2nix-env";
+  };
 };
 in
 attrs.racket2nix // attrs


### PR DESCRIPTION
Solution: Create racket2nix-env in default.nix, which depends on racket2nix.