### PR TITLE
Problem: `make` calls racket2nix-flat-nix last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: racket2nix racket2nix-flat-nix
+default: racket2nix-flat-nix racket2nix
 
 racket2nix:
 	nix-build --no-out-link


### PR DESCRIPTION
It's just slightly inconvenient when the path to a working racket2nix
is not the last line in the output from a plain 'make'.

Solution: Put racket2nix last in default target.