### PR TITLE
Problem: We are running out of file handles again

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -98,7 +98,7 @@ let mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
 
   racket-cmd = "${racket}/bin/racket -G $env/etc/racket -U -X $env/share/racket/collects";
   raco = "${racket-cmd} -N raco -l- raco";
-  maxFileDescriptors = 2048;
+  maxFileDescriptors = 3072;
 
   make-config-rktd = builtins.toFile "make-config-rktd.rkt" ''
     #lang racket
@@ -144,7 +144,7 @@ let mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     set -o pipefail
 
     if ! ulimit -n $maxFileDescriptors; then
-      echo >&2 If the number of allowed file descriptors is lower than '~2048,'
+      echo >&2 If the number of allowed file descriptors is lower than '~3072,'
       echo >&2 packages like drracket or racket-doc will not build correctly.
       echo >&2 If raising the soft limit fails '(like it just did)', you will
       echo >&2 have to raise the hard limit on your operating system.


### PR DESCRIPTION
As we are moving closer to successfully compiling htdp-lib and
racket-doc, we are once again running into to low max-file ulimit
on macOS.

Solution: Raise maxFileDescriptors to 3072.