### PR TITLE
Problem: we cannot package fractalide

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
 , stdenvNoCC ? pkgs.stdenvNoCC
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
 , cacert ? pkgs.cacert
+, nix-prefetch-git ? pkgs.nix-prefetch-git
 , racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
 , racket2nix-stage0-nix ? racket2nix-stage0.racket2nix-stage0-nix
@@ -54,7 +55,7 @@ let attrs = rec {
   racket2nix-flat-nix = racket2nix-flat-stage1-nix;
   racket2nix-env = stdenvNoCC.mkDerivation {
     phases = [];
-    buildInputs = [ racket2nix ];
+    buildInputs = [ racket2nix nix-prefetch-git ];
     name = "racket2nix-env";
   };
 };


### PR DESCRIPTION
Solution: Implement support for git and github sources.

Known limitations:

Fractalide only builds with full racket, due to #94 giving us
empty.zip for release packages.

Closes #77
Closes #20