### PR TITLE
Problem: fetchgit fetches the entire history

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -1,8 +1,8 @@
 let
   bootPkgs = import <nixpkgs> { };
-  bootFetchgit = bootPkgs.fetchgit;
-  remotePkgs = bootFetchgit {
-    url = "git://github.com/NixOS/nixpkgs-channels.git";
+  remotePkgs = bootPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-channels";
     rev = "a66ce38acea505c4b3bfac9806669d2ad8b34efa";
     sha256 = "1jrz6lkhx64mvm0h4gky9b6iaazivq69smppkx33hmrm4553dx5h";
   };


### PR DESCRIPTION
Solution: use fetchFromGithub which downloads just the
tarball at that revision