### PR TITLE
Problem: default.nix nixpkgs is not pinned

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { }
+{ pkgs ? import ./nixpkgs.nix { }
 , stdenvNoCC ? pkgs.stdenvNoCC
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
 , cacert ? pkgs.cacert

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,10 @@
+let
+  bootPkgs = import <nixpkgs> { };
+  pinnedPkgs = bootPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-channels";
+    rev = "a66ce38acea505c4b3bfac9806669d2ad8b34efa";
+    sha256 = "1jrz6lkhx64mvm0h4gky9b6iaazivq69smppkx33hmrm4553dx5h";
+  };
+in
+import pinnedPkgs

--- a/test.nix
+++ b/test.nix
@@ -1,13 +1,4 @@
-let
-  bootPkgs = import <nixpkgs> { };
-  remotePkgs = bootPkgs.fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs-channels";
-    rev = "a66ce38acea505c4b3bfac9806669d2ad8b34efa";
-    sha256 = "1jrz6lkhx64mvm0h4gky9b6iaazivq69smppkx33hmrm4553dx5h";
-  };
-in
-{ pkgs ? import remotePkgs { }
+{ pkgs ? import ./nixpkgs.nix { }
 , stdenvNoCC ? pkgs.stdenvNoCC
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
 , racket2nix ? pkgs.callPackage ./. { inherit racket; }


### PR DESCRIPTION
If some other nix expression imports us remotely, they cannot trust
that racket2nix will always build, because it's using <nixpkgs> for
pkgs.

Solution: Extract nixpkgs pinning from test.nix and use it in both
test.nix and default.nix.