### PR TITLE
Problem: extractPath doesn't work on Nix/Darwin

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -44,7 +44,10 @@
 let
 extractPath = lib.makeOverridable ({ path, src }: stdenv.mkDerivation {
   inherit path src;
-  name = builtins.elemAt (builtins.match "(|.*/)([^/]*)" path) 1;
+  name = let
+    pathComponents = builtins.split "/" path;
+    numComponents = builtins.length pathComponents;
+  in builtins.elemAt pathComponents (numComponents - 1);
   phases = "unpackPhase installPhase";
   installPhase = ''
     cp -a "${path}" $out


### PR DESCRIPTION
The regular expression is valid on Nix/Linux but not on Nix/Darwin.

Solution: Use builtins.split instead.

Closes #100