### PR TITLE
Problem: no tests verifying git and string split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,4 @@ pkgs-all:
 test:
 	nix-build --no-out-link test.nix 2>&1
 
-test-flat:
-	nix-build --no-out-link test.nix -A racket-doc-flat 2>&1
-
 .PHONY: racket2nix racket2nix-flat-nix test test-flat

--- a/test.nix
+++ b/test.nix
@@ -1,5 +1,6 @@
 { pkgs ? import ./nixpkgs.nix { }
 , stdenvNoCC ? pkgs.stdenvNoCC
+, nix-prefetch-git ? pkgs.nix-prefetch-git
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
 , racket2nix ? pkgs.callPackage ./. { inherit racket; }
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
@@ -7,21 +8,48 @@
 , racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
 }:
 
+let provided-racket = racket; in
 let attrs = rec {
   inherit pkgs;
   inherit racket2nix;
   inherit racket2nix-stage0;
-  racket-doc-nix = { extraArgs ? ""} : stdenvNoCC.mkDerivation {
-    name = "racket-doc.nix";
-    buildInputs = [ racket2nix ];
+  generateNix = { catalog, extraArgs, package }: stdenvNoCC.mkDerivation {
+    name = "${package}.nix";
+    buildInputs = [ racket2nix nix-prefetch-git ];
     phases = "installPhase";
     installPhase = ''
-      racket2nix ${extraArgs} --catalog ${racket-catalog} racket-doc > $out
+      racket2nix ${extraArgs} --catalog ${catalog} ${package} > $out
     '';
   };
-  racket-doc = pkgs.callPackage (racket-doc-nix {}) { inherit racket; };
-  racket-doc-flat-nix = racket-doc-nix { extraArgs = "--flat"; };
-  racket-doc-flat = pkgs.callPackage racket-doc-flat-nix { inherit racket; };
+  buildPackage = { catalog ? racket-catalog.merged-catalog, racket ? provided-racket
+                 , extraArgs ? "", package }:
+    let
+      nix = generateNix {
+        inherit catalog extraArgs package;
+      };
+    in
+      (pkgs.callPackage nix { inherit racket; }) // { inherit nix; };
+
+  racket-doc = buildPackage { package = "racket-doc"; };
+  racket-doc-nix = racket-doc.nix;
+  racket-doc-flat = buildPackage { package = "racket-doc"; extraArgs = "--flat"; };
+  racket-doc-flat-nix = racket-doc-flat.nix;
+  typed-map-lib = buildPackage { package = "typed-map-lib"; };
+  typed-map-lib-flat = buildPackage { package = "typed-map-lib"; extraArgs = "--flat"; };
+  br-parser-tools-lib = buildPackage { package = "br-parser-tools-lib"; };
+  br-parser-tools-lib-flat = buildPackage { package = "br-parser-tools-lib"; extraArgs = "--flat"; };
+  light-tests = stdenvNoCC.mkDerivation {
+    name = "light-tests";
+    buildInputs = [ typed-map-lib typed-map-lib-flat br-parser-tools-lib br-parser-tools-lib-flat ];
+    phases = "installPhase";
+    installPhase = ''touch $out'';
+  };
+  heavy-tests = stdenvNoCC.mkDerivation {
+    name = "heavy-tests";
+    buildInputs = [ racket-doc racket-doc-flat ];
+    phases = "installPhase";
+    installPhase = ''touch $out'';
+  };
 };
 in
-attrs.racket-doc // attrs
+attrs.light-tests // attrs

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -35,9 +35,7 @@ nix-shell stage0.nix --run true |& subfold racket2nix-stage0.prerequisites
 
 make |& subfold racket2nix
 
-## We need to build racket-doc-nix for (test.nix).pkgs below to be
-## resolvable
-nix-build --no-out-link test.nix -A racket-doc-nix |& subfold racket-doc-nix
+make test |& subfold test
 
 # Allow running travis-test.sh on macOS while full racket is not yet available
 if (( $(nix-instantiate --eval -E 'with (import ./test.nix {}).pkgs;


### PR DESCRIPTION
Solution: Add builds for typed-map-lib and br-parser-tools-lib.

 - typed-map-lib: uses git, dependency of fractalide, so we are
   testing that we can supply fractalide
 - br-parser-tools-lib: has a slash in the path= query, so we
   are testing the string split

Now that we have light tests, add them to travis.