### PR TITLE
 Problem: no convenient API for building Racket derivations 

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -1,0 +1,45 @@
+{ pkgs ? import ./nixpkgs.nix { }
+, lib ? pkgs.lib
+, stdenvNoCC ? pkgs.stdenvNoCC
+, nix-prefetch-git ? pkgs.nix-prefetch-git
+, catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
+, racket ? pkgs.callPackage ./racket-minimal.nix { }
+, racket2nix ? pkgs.callPackage ./stage0.nix { inherit racket; }
+}:
+
+let
+  isStoreSubPath = path:
+    let storePrefix = builtins.substring 0 (builtins.stringLength builtins.storeDir);
+    in (storePrefix path) == builtins.storeDir;
+  stripHash = path:
+    let
+      storeStripped = lib.removePrefix "/" (lib.removePrefix builtins.storeDir path);
+      finalLength = (builtins.stringLength storeStripped) - 33;
+    in
+      builtins.substring 33 finalLength storeStripped;
+  attrs = rec {
+    buildRacketNix = { flat, package}:
+    stdenvNoCC.mkDerivation {
+      name = "racket-package.nix";
+      outputs = [ "out" "src" ];
+      buildInputs = [ racket2nix nix-prefetch-git ];
+      phases = "installPhase";
+      flatArg = lib.optionalString flat "--flat";
+      installPhase = ''
+        mkdir $src
+        if (( ${if isStoreSubPath package then "1" else "0"} )); then
+          packageName=$src/${baseNameOf (stripHash package)}
+          cp -a ${package} $packageName
+        else
+          packageName=${package}
+        fi
+        racket2nix $flatArg --catalog ${catalog} $packageName > $out
+      '';
+    };
+    buildRacket = lib.makeOverridable ({ flat ? false, package }:
+      let nix = buildRacketNix { inherit flat package; };
+      in (pkgs.callPackage nix { inherit racket; }) // { inherit nix; }
+    );
+  };
+in
+attrs

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -5,6 +5,7 @@
 , catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
 , racket ? pkgs.callPackage ./racket-minimal.nix { }
 , racket2nix ? pkgs.callPackage ./stage0.nix { inherit racket; }
+, package ? null
 }:
 
 let
@@ -42,4 +43,4 @@ let
     );
   };
 in
-attrs
+if package != null then attrs.buildRacket { inherit package; } else attrs

--- a/catalog.nix
+++ b/catalog.nix
@@ -52,4 +52,4 @@ let attrs = rec {
   };
 };
 in
-attrs.release-catalog // attrs
+attrs.merged-catalog // attrs

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import ./nixpkgs.nix { }
 , stdenvNoCC ? pkgs.stdenvNoCC
+, build-racket ? pkgs.callPackage ./build-racket.nix { inherit racket; }
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
-, cacert ? pkgs.cacert
 , nix-prefetch-git ? pkgs.nix-prefetch-git
 , racket-catalog ? pkgs.callPackage ./catalog.nix { inherit racket; }
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
@@ -9,6 +9,7 @@
 }:
 
 let attrs = rec {
+  inherit (build-racket) buildRacket;
   racket2nix-stage1-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix.nix";
     src = ./nix;


### PR DESCRIPTION
Solution: Extract the nix generator function and caller into build-racket.

Make it more convenient to use.
Export as buildRacket in default.nix for others to use.