### PR TITLE
Problem: build-racket does not work with restrict-eval = true

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -1,7 +1,7 @@
 { pkgs ? import ./nixpkgs.nix { }
 , lib ? pkgs.lib
 , stdenvNoCC ? pkgs.stdenvNoCC
-, nix-prefetch-git ? pkgs.nix-prefetch-git
+, nix ? pkgs.nix
 , catalog ? ./catalog.rktd
 , racket ? pkgs.callPackage ./racket-minimal.nix { }
 , racket2nix ? pkgs.callPackage ./stage0.nix { inherit racket; }
@@ -23,7 +23,7 @@ let
     stdenvNoCC.mkDerivation {
       name = "racket-package.nix";
       outputs = [ "out" "src" ];
-      buildInputs = [ racket2nix nix-prefetch-git ];
+      buildInputs = [ racket2nix nix ];
       phases = "installPhase";
       flatArg = lib.optionalString flat "--flat";
       installPhase = ''

--- a/stage0.nix
+++ b/stage0.nix
@@ -1,5 +1,6 @@
 { pkgs ? import ./nixpkgs.nix { }
 , stdenvNoCC ? pkgs.stdenvNoCC
+, nix ? pkgs.nix
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
 , racket-catalog ? ./catalog.rktd
 }:
@@ -8,7 +9,7 @@ let attrs = rec {
   racket2nix-stage0-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix-stage0.nix";
     src = ./nix;
-    buildInputs = [ racket ];
+    buildInputs = [ nix racket ];
     phases = "unpackPhase installPhase";
     installPhase = ''
       racket -N racket2nix ./racket2nix.rkt --catalog ${racket-catalog} ../nix > $out


### PR DESCRIPTION
```
$ nix-build --option restrict-eval true \
  -I . -I /nix/store/8wpfckjbdwhrfrfdra6gi2f69brdyz20-nixpkgs-18.09pre140705.090b7cc8f1b/nixpkgs \
  build-racket.nix --arg package ./nix
building '/nix/store/dh56a2qmy6x65pzscxn85dkr74pkbx9v-racket-package.nix.drv'...
installing
error: access to path '/nix/store/x8fbigk4ms45j7dpfcdi97x834mmynrd-racket-package.nix-src/nix' is forbidden in restricted mode
```

Solution: When a package is located inside the store, racket2nix
refers to it as a no-op fixed-output derivation instead of as a plain
path. Example:

```
fractalide/fractalide/pkgs $ nix-build --arg racket2nix 'import ../../racket2nix {}' -A fractalide.nix | xargs grep -m 1 -A 5 _fractalide
  _fractalide = mkRacketDerivation rec {
  name = "fractalide";
  src = fixedRacketSource {
    pathname = "/nix/store/glcimhq0swvnixz0p1nyksyfcp8xql5s-racket-package.nix-src/fractalide";
    sha256 = "4918fba598b3b18a028553121f275b9f1d4558cff4eb27cea2c66ffceb5dbd25";
  };
```

`pathname` is for human eyes only, the derivation does nothing with it
except use the basename as name.

The act of taking the hash of the directory makes it appear in the
store, that's why the derivation can be a no-op.

Verified to work with `racket2nix` and with `fractalide`.

Remove dependencies on nix-prefetch-git in our nixes. If you run
racket2nix through nix, you should use a preprocessed catalog instead.

racket2nix now needs nix whenever you pass it a directory rather than
a package name, because it needs to check if that directory is in the
store. There is a narrow usecase for using racket2nix without nix
installed, but I don't think it's worth it.

Closes #126