### PR TITLE
Problem: travis fails with missing nix-instantiate

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,12 +38,12 @@ let attrs = rec {
       racket -N racket2nix ./racket2nix.rkt --flat --catalog ${racket-catalog} ../nix > $out
     '';
   };
-  racket2nix-flat-stage0 = (pkgs.callPackage racket2nix-flat-stage0-nix { inherit racket; }).racketDerivation.override {
+  racket2nix-flat-stage0 = ((pkgs.callPackage racket2nix-flat-stage0-nix { inherit racket; }).racketDerivation.override {
     src = ./nix;
     postInstall = ''
       $out/bin/racket2nix --test
     '';
-  };
+  }).overrideAttrs (oldAttrs: { buildInputs = oldAttrs.buildInputs ++ [ nix ]; });
   racket2nix-flat-stage1-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix.nix";
     src = ./nix;

--- a/test.nix
+++ b/test.nix
@@ -1,6 +1,6 @@
 { pkgs ? import ./nixpkgs.nix { }
 , stdenvNoCC ? pkgs.stdenvNoCC
-, nix-prefetch-git ? pkgs.nix-prefetch-git
+, nix ? pkgs.nix
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
 , racket2nix ? pkgs.callPackage ./. { inherit racket; }
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
@@ -15,7 +15,7 @@ let attrs = rec {
   inherit racket2nix-stage0;
   generateNix = { catalog, extraArgs, package }: stdenvNoCC.mkDerivation {
     name = "${package}.nix";
-    buildInputs = [ racket2nix nix-prefetch-git ];
+    buildInputs = [ racket2nix nix ];
     phases = "installPhase";
     installPhase = ''
       racket2nix ${extraArgs} --catalog ${catalog} ${package} > $out


### PR DESCRIPTION
`nix` is missing as a dependency in two places, partly due to #129.

Solution: Add nix dependency.