### PR TITLE
Problem: racket-build has unnecessary complexity

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -9,32 +9,16 @@
 }:
 
 let
-  isStoreSubPath = path:
-    let storePrefix = builtins.substring 0 (builtins.stringLength builtins.storeDir);
-    in (storePrefix path) == builtins.storeDir;
-  stripHash = path:
-    let
-      storeStripped = lib.removePrefix "/" (lib.removePrefix builtins.storeDir path);
-      finalLength = (builtins.stringLength storeStripped) - 33;
-    in
-      builtins.substring 33 finalLength storeStripped;
   attrs = rec {
     buildRacketNix = { flat, package}:
     stdenvNoCC.mkDerivation {
       name = "racket-package.nix";
-      outputs = [ "out" "src" ];
+      inherit package;
       buildInputs = [ racket2nix nix ];
       phases = "installPhase";
       flatArg = lib.optionalString flat "--flat";
       installPhase = ''
-        mkdir $src
-        if (( ${if isStoreSubPath package then "1" else "0"} )); then
-          packageName=$src/${baseNameOf (stripHash package)}
-          cp -a ${package} $packageName
-        else
-          packageName=${package}
-        fi
-        racket2nix $flatArg --catalog ${catalog} $packageName > $out
+        racket2nix $flatArg --catalog ${catalog} $package > $out
       '';
     };
     buildRacket = lib.makeOverridable ({ flat ? false, package }:

--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -54,8 +54,15 @@ extractPath = lib.makeOverridable ({ path, src }: stdenv.mkDerivation {
   '';
 });
 
+stripHash = path:
+  let
+    storeStripped = lib.removePrefix "/" (lib.removePrefix builtins.storeDir path);
+    finalLength = (builtins.stringLength storeStripped) - 33;
+  in
+    builtins.substring 33 finalLength storeStripped;
+
 fixedRacketSource = { pathname, sha256 }: stdenv.mkDerivation {
-  name = baseNameOf pathname;
+  name = baseNameOf (stripHash pathname);
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
   outputHash = sha256;

--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -41,17 +41,4 @@ function subfold() {
   '
 }
 
-make pkgs-all |& subfold catalog
-
-nix-shell stage0.nix --run true |& subfold racket2nix-stage0.prerequisites
-
-make |& subfold racket2nix
-
-make test |& subfold test
-
-# Allow running travis-test.sh on macOS while full racket is not yet available
-if (( $(nix-instantiate --eval -E 'if (import ./nixpkgs.nix {}).racket.meta.available then 1 else 0') )); then
-  nix-build --no-out-link -E 'with import ./nixpkgs.nix {}; callPackage ./. {}' |& subfold racket2nix.full-racket
-fi
-
-./support/utils/nix-build-travis-fold.sh build-racket.nix --arg package ./nix
+nix-build --option restrict-eval true -I . -I $(readlink ~/.nix-defexpr/channels/nixpkgs) --show-trace "$@" |& subfold ${!#}


### PR DESCRIPTION
The `racket-package.nix.src` dance is for the purpose of making sure
the racket derivation depends on the subtree only, and not the whole
source repo. Now we have the fixed-output dance, which takes care of
that too.

Solution: Remove the `src` output from the `racket-package.nix`
derivation.

Add build-racket-packaged nix to the Travis tests, while also phasing
in use of nix-build-travis-fold.sh.

This nix-build-travis-fold.sh also uses restrict-eval, so that we
catch those issues before we reach Hydra.