### PR TITLE
Problem: nix-build-travis-fold fails on Travis darwin

### DIFF
--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -41,4 +41,7 @@ function subfold() {
   '
 }
 
-nix-build --option restrict-eval true -I . -I $(readlink ~/.nix-defexpr/channels/nixpkgs) --show-trace "$@" |& subfold ${!#}
+nix-build --option restrict-eval true \
+  -I . -I "$(readlink ~/.nix-defexpr/channels/nixpkgs)" \
+  -I "$(readlink /nix/var/nix/profiles/per-user/root/channels/nixpkgs)" \
+  --show-trace "$@" |& subfold ${!#}


### PR DESCRIPTION
1. The readlink returns empty string, so the arguments get misaligned.
2. If it would work, the lack of an include path means the
   restrict-eval would complain.

Solution: Quote the include paths, add `profiles/per-user/root`.

The test environment on Travis darwin finds nixpkgs in
`/nix/var/nix/profiles/per-user/root/channels`.