### PR TITLE
Problem: not stripping off the store prefix and hash off package name

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -367,6 +367,12 @@ EOM
          (set! store-path (with-input-from-string store-path-string read-json))
          store-path]))))
 
+(define (strip-store-prefix pathname)
+  (define store-path (discover-store-path))
+  (cond [(string-prefix? pathname store-path)
+         (substring pathname (+ (string-length store-path) 34))]
+        [else pathname]))
+
 (define (generate-local-file-src pathname)
   (cond [(string-prefix? pathname (discover-store-path))
          (generate-noop-fixed-output-src pathname)]
@@ -697,7 +703,7 @@ EOM
 
   (define package-name (cond
     [(and package-name-or-path (string-contains? package-name-or-path "/"))
-     (define name (string-replace package-name-or-path #rx".*/" ""))
+     (define name (string-replace (strip-store-prefix package-name-or-path) #rx".*/" ""))
      (define path package-name-or-path)
      (hash-set!
        pkg-details name


### PR DESCRIPTION
$ ~/git/fractalide/racket2nix/racket2nix --catalog catalog.rktd /nix/store/h7s2sqjx0jfj6w0a7x7wh7vaw35hivw9-fractalide > h7s2.nix && nix-build --no-out-link h7s2.nix
/nix/store/8138lplmikk6cpiqrqrd5iy5bg63vdqk-h7s2sqjx0jfj6w0a7x7wh7vaw35hivw9-fractalide

Solution: Implement and use (strip-store-prefix).

$ ./racket2nix --catalog catalog.rktd /nix/store/h7s2sqjx0jfj6w0a7x7wh7vaw35hivw9-fractalide > h7s2.nix && nix-build --no-out-link h7s2.nix
/nix/store/4wl3dyz14ljj1nnnr8rszan3xgpk662b-fractalide

Closes #135