### PR TITLE
Problem: memoize does not build

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -11,6 +11,7 @@
 (define never-dependency-names '("racket"))
 (define terminal-package-names '("racket-lib"))
 (define force-reverse-circular-build-inputs #hash(
+  ["memoize" . ("scribble-lib")]
   ["racket-index" . ("scribble-lib")]
   ["racket-doc" . ("scribble-lib")]
 ))


### PR DESCRIPTION
```
open-output-file: cannot open output file
  path: /nix/store/r25bh9mk7n51rkxsm5q1n96dd0rv92aq-scribble-lib-env/share/racket/pkgs/scribble-lib/scribble/doc/lang/compiled/tmp15284803211528480321753
  system error: Permission denied; errno=13
  compilation context...:
   /nix/store/mjqwdni00nnsv0f8qb13nqg91k9ihl60-memoize-env/share/racket/pkgs/memoize/memoize/memoize.scrbl
```

Solution: Add memoize with scribble-lib to `force-reverse-circular-build-inputs`.