### PR TITLE
Problem: darwin: nix.conf didn't take

### DIFF
--- a/support/utils/setup-hydra.fractalide.com.sh
+++ b/support/utils/setup-hydra.fractalide.com.sh
@@ -23,3 +23,4 @@ trusted-public-keys = $nixos_key $fracta_key
 EOF
 } > ${nix_conf}.new
 mv ${nix_conf}.new $nix_conf
+pkill -HUP nix-daemon || true


### PR DESCRIPTION
Result: hydra.fractalide.com cache is not being used.

Solution: Kick nix-daemon, so that it reloads conf.

This only affected darwin, because linux Travis uses single-user Nix.

Don't fail if there is no nix-daemon.