### PR TITLE
Problem: Simple nix-build broken

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 , racket-catalog ? ./catalog.rktd
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
 , racket2nix-stage0-nix ? racket2nix-stage0.racket2nix-stage0-nix
-, system ? builtins.system
+, system ? builtins.currentSystem
 }:
 
 let attrs = rec {


### PR DESCRIPTION
It's spelled builtins.currentSystem, not builtins.system.

release.nix sets pkgs explicitly, so default.nix never had to fallback
to the system parameter. But when building with default.nix directly,
build fails.

Solution: Use builtins.currentSystem as the system default.