### PR TITLE
Problem: No equivalent of overrideAttrs

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -242,7 +242,10 @@ mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridable (
     find $env/share/racket/collects $env/lib/racket -lname "$racket/*" -delete
     find $env/share/racket/collects $env/lib/racket $env/bin -type d -empty -delete
   '';
-} // attrs)) suppliedAttrs; in racketDerivation // { inherit racketDerivation; };
+} // attrs)) suppliedAttrs; in racketDerivation // {
+  inherit racketDerivation;
+  overrideRacketDerivation = f: mkRacketDerivation (suppliedAttrs // (f suppliedAttrs));
+};
 
 
 EOM


### PR DESCRIPTION
It's really useful to be able to override a function call and have
access to the parameters of the original call.

In particular, this is important if you want to buildRacket and then
modify the parameters of the derivation it generates.

Solution: Add overrideRacketDerivation to mkRacketDerivation output.