### PR TITLE
Problem: Some outdated workarounds are still around.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 , nix-prefetch-git ? pkgs.nix-prefetch-git
 , racket-catalog ? ./catalog.rktd
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
-, racket2nix-stage0-nix ? racket2nix-stage0.racket2nix-stage0-nix
+, racket2nix-stage0-nix ? racket2nix-stage0.nix
 , system ? builtins.currentSystem
 , package ? null
 , flat ? false
@@ -20,12 +20,11 @@ let attrs = rec {
     buildInputs = [ nix racket2nix-stage0 ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket2nix --catalog ${racket-catalog} ../nix > $out
+      racket2nix --catalog ${racket-catalog} $src > $out
       diff ${racket2nix-stage0-nix} $out
     '';
   };
   racket2nix-stage1 = ((pkgs.callPackage racket2nix-stage1-nix { inherit racket; }).racketDerivation.override {
-    src = ./nix;
     postInstall = ''
       $out/bin/racket2nix --test
     '';
@@ -38,11 +37,10 @@ let attrs = rec {
     buildInputs = [ nix racket ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket -N racket2nix ./racket2nix.rkt --flat --catalog ${racket-catalog} ../nix > $out
+      racket -N racket2nix ./racket2nix.rkt --flat --catalog ${racket-catalog} $src > $out
     '';
   };
   racket2nix-flat-stage0 = ((pkgs.callPackage racket2nix-flat-stage0-nix { inherit racket; }).racketDerivation.override {
-    src = ./nix;
     postInstall = ''
       $out/bin/racket2nix --test
     '';
@@ -53,7 +51,7 @@ let attrs = rec {
     buildInputs = [ nix racket2nix-flat-stage0 ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket2nix --flat --catalog ${racket-catalog} ../nix > $out
+      racket2nix --flat --catalog ${racket-catalog} $src > $out
       diff ${racket2nix-flat-stage0-nix} $out
     '';
   };

--- a/stage0.nix
+++ b/stage0.nix
@@ -5,17 +5,16 @@
 , racket-catalog ? ./catalog.rktd
 }:
 
-let attrs = rec {
-  racket2nix-stage0-nix = stdenvNoCC.mkDerivation {
+let
+  stage0-nix = stdenvNoCC.mkDerivation {
     name = "racket2nix-stage0.nix";
     src = ./nix;
     buildInputs = [ nix racket ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket -N racket2nix ./racket2nix.rkt --catalog ${racket-catalog} ../nix > $out
+      racket -N racket2nix ./racket2nix.rkt --catalog ${racket-catalog} $src > $out
     '';
   };
-  racket2nix-stage0 = (pkgs.callPackage racket2nix-stage0-nix { inherit racket; }).racketDerivation.override { src = ./nix; };
-};
+  stage0 = pkgs.callPackage stage0-nix { inherit racket; };
 in
-attrs.racket2nix-stage0 // attrs
+stage0 // { nix = stage0-nix; }


### PR DESCRIPTION
The racket2nix bootstrap refers to ../nix, then has to override it
when using the generated nix file. It can just refer to the nix
store alias instead to make it non-relative and remove the need
for an override.

Solution: Refer to $src instead of ../nix in the bootstraps.

Also make stage0 look more like a buildRacket-generated derivation.