### PR TITLE
Problem: Flattening fails to include some deps

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -12,7 +12,7 @@
 let
   default-catalog = catalog;
   attrs = rec {
-    buildRacketNix = { catalog ? catalog, flat, package}:
+    buildRacketNix = { catalog, flat, package}:
     stdenvNoCC.mkDerivation {
       name = "racket-package.nix";
       inherit package;

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -11,7 +11,7 @@
 
 let
   attrs = rec {
-    buildRacketNix = { flat, package}:
+    buildRacketNix = { catalog ? catalog, flat, package}:
     stdenvNoCC.mkDerivation {
       name = "racket-package.nix";
       inherit package;
@@ -22,10 +22,10 @@ let
         racket2nix $flatArg --catalog ${catalog} $package > $out
       '';
     };
-    buildRacket = lib.makeOverridable ({ flat ? false, package }:
-      let nix = buildRacketNix { inherit flat package; };
+    buildRacket = lib.makeOverridable ({ catalog ? catalog, flat ? false, package }:
+      let nix = buildRacketNix { inherit catalog flat package; };
       in (pkgs.callPackage nix { inherit racket; }) // { inherit nix; }
     );
   };
 in
-if package != null then attrs.buildRacket { inherit package flat; } else attrs
+if package != null then attrs.buildRacket { inherit catalog package flat; } else attrs

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -10,6 +10,7 @@
 }:
 
 let
+  default-catalog = catalog;
   attrs = rec {
     buildRacketNix = { catalog ? catalog, flat, package}:
     stdenvNoCC.mkDerivation {
@@ -22,7 +23,7 @@ let
         racket2nix $flatArg --catalog ${catalog} $package > $out
       '';
     };
-    buildRacket = lib.makeOverridable ({ catalog ? catalog, flat ? false, package }:
+    buildRacket = lib.makeOverridable ({ catalog ? default-catalog, flat ? false, package }:
       let nix = buildRacketNix { inherit catalog flat package; };
       in (pkgs.callPackage nix { inherit racket; }) // { inherit nix; }
     );

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
 , racket ? pkgs.callPackage ./racket-minimal.nix {}
 , nix ? pkgs.nix
 , nix-prefetch-git ? pkgs.nix-prefetch-git
-, racket-catalog ? ./catalog.rktd
+, catalog ? ./catalog.rktd
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
 , racket2nix-stage0-nix ? racket2nix-stage0.nix
 , system ? builtins.currentSystem
@@ -20,7 +20,7 @@ let attrs = rec {
     buildInputs = [ nix racket2nix-stage0 ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket2nix --catalog ${racket-catalog} $src > $out
+      racket2nix --catalog ${catalog} $src > $out
       diff ${racket2nix-stage0-nix} $out
     '';
   };
@@ -37,7 +37,7 @@ let attrs = rec {
     buildInputs = [ nix racket ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket -N racket2nix ./racket2nix.rkt --flat --catalog ${racket-catalog} $src > $out
+      racket -N racket2nix ./racket2nix.rkt --flat --catalog ${catalog} $src > $out
     '';
   };
   racket2nix-flat-stage0 = ((pkgs.callPackage racket2nix-flat-stage0-nix { inherit racket; }).racketDerivation.override {
@@ -51,7 +51,7 @@ let attrs = rec {
     buildInputs = [ nix racket2nix-flat-stage0 ];
     phases = "unpackPhase installPhase";
     installPhase = ''
-      racket2nix --flat --catalog ${racket-catalog} $src > $out
+      racket2nix --flat --catalog ${catalog} $src > $out
       diff ${racket2nix-flat-stage0-nix} $out
     '';
   };
@@ -63,4 +63,4 @@ let attrs = rec {
   };
 };
 in
-if package == null then (attrs.racket2nix // attrs) else attrs.buildRacket { inherit package flat; }
+if package == null then (attrs.racket2nix // attrs) else attrs.buildRacket { inherit catalog package flat; }

--- a/integration-test/a-depends-on-b/info.rkt
+++ b/integration-test/a-depends-on-b/info.rkt
@@ -1,0 +1,7 @@
+#lang info
+(define version "0.0")
+(define collection "a")
+(define deps '("base" "b-depends-on-c"))
+(define build-deps '())
+(define pkg-desc "Dummy package to validate that depending on circular dependencies works correctly.")
+(define pkg-authors '("claes.wallin@greatsinodevelopment.com"))

--- a/integration-test/a-depends-on-b/main.rkt
+++ b/integration-test/a-depends-on-b/main.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(require b)
+
+(provide (all-defined-out))
+
+(define (dummy) (b-dummy 42))

--- a/integration-test/b-depends-on-c/info.rkt
+++ b/integration-test/b-depends-on-c/info.rkt
@@ -1,0 +1,7 @@
+#lang info
+(define version "0.0")
+(define collection "b")
+(define deps '("base" "c-depends-on-b"))
+(define build-deps '())
+(define pkg-desc "Dummy package to validate that depending on circular dependencies works correctly.")
+(define pkg-authors '("claes.wallin@greatsinodevelopment.com"))

--- a/integration-test/b-depends-on-c/main.rkt
+++ b/integration-test/b-depends-on-c/main.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(require c)
+
+(provide (all-defined-out))
+
+(define (b-dummy x) (c-dummy x))

--- a/integration-test/b-depends-on-c/what-c-needs.rkt
+++ b/integration-test/b-depends-on-c/what-c-needs.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+(provide (all-defined-out))
+
+(define (b-c-b-dummy x) (printf "What do you get if you multiply six by nine? ~a~n" x))

--- a/integration-test/c-depends-on-b/info.rkt
+++ b/integration-test/c-depends-on-b/info.rkt
@@ -1,0 +1,7 @@
+#lang info
+(define version "0.0")
+(define collection "c")
+(define deps '("base" "b-depends-on-c"))
+(define build-deps '())
+(define pkg-desc "Dummy package to validate that depending on circular dependencies works correctly.")
+(define pkg-authors '("claes.wallin@greatsinodevelopment.com"))

--- a/integration-test/c-depends-on-b/main.rkt
+++ b/integration-test/c-depends-on-b/main.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(require b/what-c-needs)
+
+(provide (all-defined-out))
+
+(define (c-dummy x) (b-c-b-dummy x))

--- a/integration-test/catalog.nix
+++ b/integration-test/catalog.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import ../nixpkgs {}
+, racket2nix ? import ./.. {}
+, catalog ? ../catalog.rktd
+}:
+
+pkgs.runCommand "catalog.rktd" {
+  buildInputs = [ racket2nix ];
+  src = ./.;
+  inherit catalog;
+} ''
+  cd $src
+  racket2nix --catalog catalog.rktd.in --catalog $catalog --export-catalog a-depends-on-b |
+    sed -e "s,\"./,\"$src/,g" > $out
+''

--- a/integration-test/catalog.rktd.in
+++ b/integration-test/catalog.rktd.in
@@ -1,0 +1,20 @@
+#hash(
+      ("a-depends-on-b"
+       .
+       #hash((dependencies . ("base" "b-depends-on-c"))
+             (name . "a-depends-on-b")
+             (checksum . "")
+             (source . "./a-depends-on-b")))
+      ("b-depends-on-c"
+       .
+       #hash((dependencies . ("base" "c-depends-on-b"))
+             (name . "b-depends-on-c")
+             (checksum . "")
+             (source . "./b-depends-on-c")))
+      ("c-depends-on-b"
+       .
+       #hash((dependencies . ("base" "b-depends-on-c"))
+             (name . "c-depends-on-b")
+             (checksum . "")
+             (source . "./c-depends-on-b")))
+)

--- a/integration-test/default.nix
+++ b/integration-test/default.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import ../nixpkgs {}
+, racket2nix ? import ./.. {}
+, buildRacket ? racket2nix.buildRacket
+, catalog ? import ./catalog.nix {}
+}:
+
+rec {
+  circular-subdeps = buildRacket { package = "a-depends-on-b"; inherit catalog; flat = false; };
+  circular-subdeps-flat = circular-subdeps.override { flat = true; };
+}

--- a/integration-test/update-catalog-sh
+++ b/integration-test/update-catalog-sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -E "with import ../nixpkgs {}; with import ../ {}; buildEnv { paths = [ racket2nix nix bash ]; }" -i bash
+
+set -e
+set -u
+
+SCRIPT_NAME=${BASH_SOURCE[0]##*/}
+cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}"
+
+racket2nix --catalog ../catalog.rktd ./a-depends-on-b --export-catalog

--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -97,16 +97,18 @@ mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridable (
     runHook preUnpack
     for unpackSrc in $srcs; do
       unpackName=$(stripSuffix $(stripHash $unpackSrc))
-      mkdir $unpackName
-      cd $unpackName
-      unpackFile $unpackSrc
-      cd -
-      unpackedFiles=( $unpackName/* )
-      if [ "''${unpackedFiles[*]}" = "$unpackName/$unpackName" ]; then
-        mv $unpackName _
-        chmod u+w _/$unpackName
-        mv _/$unpackName $unpackName
-        rmdir _
+      if ! [ -d $unpackName ]; then
+        mkdir $unpackName
+        cd $unpackName
+        unpackFile $unpackSrc
+        cd -
+        unpackedFiles=( $unpackName/* )
+        if [ "''${unpackedFiles[*]}" = "$unpackName/$unpackName" ]; then
+          mv $unpackName _
+          chmod u+w _/$unpackName
+          mv _/$unpackName $unpackName
+          rmdir _
+        fi
       fi
     done
     chmod u+w -R .
@@ -449,8 +451,8 @@ EOM
   (define srcs
     (cond
       [(pair? reverse-circular-build-inputs)
-       (define srcs-refs (string-join (map (lambda (s) (format "_~a.src" s)) reverse-circular-build-inputs)))
-       (format "~n  extraSrcs = [ ~a ];" srcs-refs)]
+       (define srcs-refs (string-join (map (lambda (s) (format "_~a.srcs" s)) reverse-circular-build-inputs) " ++ "))
+       (format "~n  extraSrcs = ~a;" srcs-refs)]
       [else ""]))
 
   (format derivation-template name (string-join (list src srcs) "")

--- a/test.nix
+++ b/test.nix
@@ -6,6 +6,7 @@
 , racket2nix-stage0 ? pkgs.callPackage ./stage0.nix { inherit racket; }
 , colordiff ? pkgs.colordiff
 , racket-catalog ? ./catalog.rktd
+, integration-test ? import ./integration-test {}
 }:
 
 let provided-racket = racket; in
@@ -40,7 +41,8 @@ let attrs = rec {
   br-parser-tools-lib-flat = buildPackage { package = "br-parser-tools-lib"; extraArgs = "--flat"; };
   light-tests = stdenvNoCC.mkDerivation {
     name = "light-tests";
-    buildInputs = [ typed-map-lib typed-map-lib-flat br-parser-tools-lib br-parser-tools-lib-flat ];
+    buildInputs = [ typed-map-lib typed-map-lib-flat br-parser-tools-lib br-parser-tools-lib-flat ] ++
+      builtins.attrValues integration-test;
     phases = "installPhase";
     installPhase = ''touch $out'';
   };


### PR DESCRIPTION
Flattening makes all your deps circular deps, which is supposed to
mean everything gets compiled in one big derivation. But it's not that
simple.

 - The reverseCircularDeps mechanism makes the assumption that the
   catalog resolver went through the circle and added all the deps as
   reverse circular deps to the top derivation.
 - The flatten mechanism makes the assumption that adding a dep to
   reverseCircularDeps is enough.

Solution: reverseCircularDeps: Don't add the src, add the srcs.

Each derivation calculates srcs from its own reverseCircularDeps, so
this makes srcs accumulate all the packages necessary. Unfortunately,
this means it adds redundant srcs, so we can't be as strict about
those any more. We'll silently skip unpacking a src with a name that
we already unpacked.

This is the quick and easy solution. A more correct solution would be
to resolve the catalog differently in flattening mode: Don't percolate
circular dependencies to the top and remove them as dependencies, just
break the circle at the bottom and be done.

Closes #156