### PR TITLE
Problem: racket-minimal: The pkgs default never worked

### DIFF
--- a/racket-minimal.nix
+++ b/racket-minimal.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <stdenv> {}
+{ pkgs ? import ../nixpkgs {}
 , stdenv ? pkgs.stdenv
 , libiconv ? pkgs.libiconv
 }:


### PR DESCRIPTION
Typo: stdenv instead of nixpkgs

But we never made use of the default, so it went unnoticed.

Solution: Use the pinned nixpkgs as default instead.