### PR TITLE
 Problem: Hydra builds Darwin integration tests on Linux

### DIFF
--- a/integration-test/default.nix
+++ b/integration-test/default.nix
@@ -5,7 +5,9 @@
 , racket ? pkgs.callPackage ../racket-minimal.nix {}
 }:
 
-rec {
+let attrs = rec {
   circular-subdeps = buildRacket { package = "a-depends-on-b"; inherit catalog; flat = false; };
   circular-subdeps-flat = circular-subdeps.override { flat = true; };
-}
+}; in
+
+attrs // { inherit attrs; }

--- a/test.nix
+++ b/test.nix
@@ -6,6 +6,7 @@
 , integration-test ? pkgs.callPackage ./integration-test { inherit racket; }
 }:
 
+let it-attrs = integration-test.attrs; in
 let
   buildRacketAndFlat = package: (buildRacket { inherit package; }) // {
     flat = buildRacket { inherit package; flat = true; };
@@ -28,7 +29,7 @@ let
     phases = "installPhase";
     installPhase = ''touch $out'';
   };
-  inherit integration-test;
+  integration-test = it-attrs;
 };
 in
 attrs.light-tests // attrs


### PR DESCRIPTION


The `system` and `racket` properties don't propagate properly down to
the `integration-test` expression.

Solution: Replace imports with `callPackage`, make sure to pass that
`racket` along.

Closes #163

I think the trouble in these commits shows that having racket
explicitly passed everywhere is a problem. It's better to make
a proper overlay to pkgs, and parameterize racket that way instead.

It's not as simple as overlaying `racket = self.racket-minimal`, as
racket-minimal is a derivative of racket and that creates a recursion.
Instead, racket-minimal is going to have to be derived from a grounded
nixpkgs.

I'm thinking that the best way is probably to import a grounded racket
as racket-full, dump nixpkgs racket-minimal (it's not many lines) into
our repo, and make it derive from racket-full, plus our libiconv fix.