### PR TITLE
Problem: No need for two one-liners

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -29,4 +29,4 @@ let
     );
   };
 in
-if package != null then attrs.buildRacket { inherit catalog package flat; } else attrs
+attrs


### PR DESCRIPTION
default.nix handles the command-line call to buildRacket, but
build-racket.nix still has it too.

Solution: Remove one-liner code from build-racket.nix.