### PR TITLE
 Problem: Accumulated technical debt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,13 @@
-default: racket2nix-flat-nix racket2nix
+default: racket2nix
 
 racket2nix:
 	nix-build --no-out-link
 
-racket2nix-flat-nix:
-	nix-build --no-out-link -A racket2nix-flat-nix
-
-pkgs-all:
-	nix-build --out-link pkgs-all catalog.nix
+release:
+	./support/utils/nix-build-travis-fold.sh -I racket2nix=$(PWD) --no-out-link release.nix
+        echo
 
 test:
 	nix-build --no-out-link test.nix 2>&1
 
-.PHONY: racket2nix racket2nix-flat-nix test test-flat
+.PHONY: racket2nix test

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -5,24 +5,23 @@
 }:
 
 let
-  inherit (pkgs) lib nix racket racket2nix stdenvNoCC;
+  inherit (pkgs) lib nix racket racket2nix runCommand;
   default-catalog = catalog;
   attrs = rec {
     buildRacketNix = { catalog, flat, package}:
-    stdenvNoCC.mkDerivation {
-      name = "racket-package.nix";
+    runCommand "racket-package.nix" {
       inherit package;
       buildInputs = [ racket2nix nix ];
-      phases = "installPhase";
       flatArg = lib.optionalString flat "--flat";
-      installPhase = ''
-        racket2nix $flatArg --catalog ${catalog} $package > $out
-      '';
-    };
+    } ''
+      racket2nix $flatArg --catalog ${catalog} $package > $out
+    '';
     buildRacket = lib.makeOverridable ({ catalog ? default-catalog, flat ? false, package }:
       let nix = buildRacketNix { inherit catalog flat package; };
-      in (pkgs.callPackage nix { inherit racket; }) // { inherit nix; }
+      in (pkgs.callPackage nix { inherit racket; }) // { inherit nix; } //
+        lib.optionalAttrs (! flat) { flat = buildRacket { inherit catalog package; flat = true; }; }
     );
+    buildRacketPackage = package: buildRacket { inherit package; };
   };
 in
 attrs

--- a/catalog.nix
+++ b/catalog.nix
@@ -4,46 +4,44 @@
 }:
 
 let
-inherit (pkgs) cacert racket stdenvNoCC;
+inherit (pkgs) cacert racket runCommand;
 attrs = rec {
-  release-catalog = stdenvNoCC.mkDerivation {
-    name = "release-catalog";
+  releaseCatalog = runCommand "release-catalog" {
     src = ./nix;
     buildInputs = [ racket ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      $racket/bin/racket -N dump-catalogs ./dump-catalogs.rkt https://download.racket-lang.org/releases/6.12/catalog/ > $out
-    '';
-    inherit racket;
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     outputHashMode = "flat";
     outputHashAlgo = "sha256";
     outputHash = "1p8f4yrnv9ny135a41brxh7k740aiz6m41l67bz8ap1rlq2x7pgm";
-  };
-  live-catalog = stdenvNoCC.mkDerivation {
-    name = "live-catalog";
+  } ''
+    cd $src
+    racket -N dump-catalogs ./dump-catalogs.rkt \
+      https://download.racket-lang.org/releases/6.12/catalog/ > $out
+  '';
+  liveCatalog = runCommand "live-catalog" {
     src = ./nix;
     buildInputs = [ racket ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      $racket/bin/racket -N dump-catalogs ./dump-catalogs.rkt \
-        https://web.archive.org/web/20180331093137if_/https://pkgs.racket-lang.org/ > $out
-    '';
     inherit racket;
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     outputHashMode = "flat";
     outputHashAlgo = "sha256";
     outputHash = "1snqa4wd5j14zmd4slqhcf6bmvqfd91mivil5294gjyxl1rirg7r";
-  };
-  mergedUnfilteredCatalog = pkgs.runCommand "merged-unfiltered-catalog.rktd" {
-    inherit overrides racket;
+  } ''
+    cd $src
+    racket -N dump-catalogs ./dump-catalogs.rkt \
+      https://web.archive.org/web/20180331093137if_/https://pkgs.racket-lang.org/ > $out
+  '';
+  mergedUnfilteredCatalog = runCommand "merged-unfiltered-catalog.rktd" {
+    src = ./nix;
+    inherit liveCatalog overrides releaseCatalog;
     buildInputs = [ racket ];
   } ''
-    $racket/bin/racket -N export-catalog ${./nix/racket2nix.rkt} \
+    cd $src
+    racket -N export-catalog ./racket2nix.rkt \
       --export-catalog --no-process-catalog --catalog $overrides \
-      --catalog ${release-catalog} --catalog ${live-catalog} > $out
+      --catalog $releaseCatalog --catalog $liveCatalog > $out
   '';
-  merged-catalog = pkgs.runCommand "merged-catalog.rktd" {
+  merged-catalog = runCommand "merged-catalog.rktd" {
     inherit exclusions mergedUnfilteredCatalog racket;
     buildInputs = [ racket ];
     filterCatalog = builtins.toFile "filter-catalog.scm" ''
@@ -58,17 +56,14 @@ attrs = rec {
                   (hash-set h k v)))))
     '';
   } ''
-    $racket/bin/racket -N filter-catalog $filterCatalog $exclusions \
+    racket -N filter-catalog $filterCatalog $exclusions \
       < $mergedUnfilteredCatalog > $out
   '';
-  pretty-merged-catalog = stdenvNoCC.mkDerivation {
-    name = "pretty-merged-catalog.rktd";
+  pretty-merged-catalog = runCommand "pretty-merged-catalog.rktd" {
     buildInputs = [ racket ];
-    phases = "installPhase";
-    installPhase = ''
-      ${racket}/bin/racket -e '(pretty-print (read))' < ${merged-catalog} > $out
-    '';
-  };
+  } ''
+    racket -e '(pretty-print (read))' < ${merged-catalog} > $out
+  '';
 };
 in
-attrs.merged-catalog // attrs
+attrs.merged-catalog // attrs // { inherit attrs; }

--- a/default.nix
+++ b/default.nix
@@ -6,57 +6,10 @@
 }:
 
 let
-inherit (pkgs) buildRacket nix nix-prefetch-git racket racket2nix-stage0 stdenvNoCC;
-attrs = rec {
-  inherit buildRacket;
-  racket2nix-stage1-nix = stdenvNoCC.mkDerivation {
-    name = "racket2nix.nix";
-    src = ./nix;
-    buildInputs = [ nix racket2nix-stage0 ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      racket2nix --catalog ${catalog} $src > $out
-      diff ${racket2nix-stage0.nix} $out
-    '';
+  inherit (pkgs) buildRacket racket2nix-stage1;
+  attrs = pkgs // {
+    racket2nix = racket2nix-stage1;
   };
-  racket2nix-stage1 = ((pkgs.callPackage racket2nix-stage1-nix { inherit racket; }).racketDerivation.override {
-    postInstall = ''
-      $out/bin/racket2nix --test
-    '';
-  }).overrideAttrs (oldAttrs: { buildInputs = oldAttrs.buildInputs ++ [ nix ]; });
-  racket2nix = racket2nix-stage1;
-
-  racket2nix-flat-stage0-nix = stdenvNoCC.mkDerivation {
-    name = "racket2nix.nix";
-    src = ./nix;
-    buildInputs = [ nix racket ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      racket -N racket2nix ./racket2nix.rkt --flat --catalog ${catalog} $src > $out
-    '';
-  };
-  racket2nix-flat-stage0 = ((pkgs.callPackage racket2nix-flat-stage0-nix { inherit racket; }).racketDerivation.override {
-    postInstall = ''
-      $out/bin/racket2nix --test
-    '';
-  }).overrideAttrs (oldAttrs: { buildInputs = oldAttrs.buildInputs ++ [ nix ]; });
-  racket2nix-flat-stage1-nix = stdenvNoCC.mkDerivation {
-    name = "racket2nix.nix";
-    src = ./nix;
-    buildInputs = [ nix racket2nix-flat-stage0 ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      racket2nix --flat --catalog ${catalog} $src > $out
-      diff ${racket2nix-flat-stage0-nix} $out
-    '';
-  };
-  racket2nix-flat-nix = racket2nix-flat-stage1-nix;
-  racket2nix-env = stdenvNoCC.mkDerivation {
-    phases = [];
-    buildInputs = [ nix nix-prefetch-git racket2nix ];
-    name = "racket2nix-env";
-  };
-};
 in
 if package == null then (attrs.racket2nix // attrs) else
 buildRacket { inherit catalog package flat; }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4,12 +4,19 @@
 , ...
 }@args:
 
-pkgs (args // { overlays = [ (self: super: let racket2nix-pkgs = {
-  racket-full = (pkgs (removeAttrs args [ "overlays" ])).racket;
+let
+pkgsFn = args: args.pkgs ((removeAttrs args [ "pkgs" ]) // { overlays = [ (self: super: let racket2nix-pkgs = {
+  racket-full = (args.pkgs (removeAttrs args [ "overlays" "pkgs" ])).racket;
   racket-minimal = self.callPackage ../racket-minimal {};
   racket = self.racket-minimal;
 
   racket2nix-stage0 = self.callPackage ../stage0.nix {};
+  racket2nix-stage1 = self.callPackage ../stage1.nix {};
   racket2nix = self.racket2nix-stage0;
-  inherit (self.callPackage ../build-racket.nix {}) buildRacket;
-}; in racket2nix-pkgs // { inherit racket2nix-pkgs; }) ] ++ overlays; })
+  inherit (self.callPackage ../build-racket.nix {}) buildRacket buildRacketPackage;
+}; in racket2nix-pkgs // { inherit racket2nix-pkgs; }) ] ++ args.overlays; });
+makeOverridable = g: args: (g (args // { overlays = args.overlays ++ [
+  (self: super: { overridePkgs = f: makeOverridable g (args // (f args)); })
+]; }));
+in
+makeOverridable pkgsFn ({ inherit pkgs overlays system; } // args)

--- a/release.nix
+++ b/release.nix
@@ -9,7 +9,6 @@ let
   genJobs = pkgs: rec {
     pkgs-all = pkgs.callPackage (racket2nixPath "catalog.nix") {};
     racket2nix = pkgs.callPackage <racket2nix> {};
-    racket2nix-flat-nix = racket2nix.racket2nix-flat-nix;
     test = pkgs.callPackage (racket2nixPath "test.nix") {};
   };
 in
@@ -23,6 +22,5 @@ in
     racket-full = genJobs (pkgs { overlays = [ (self: super: { racket = self.racket-full; }) ]; });
   } // lib.optionalAttrs isTravis {
     stage0-nix-prerequisites = (pkgs {}).racket2nix-stage0.buildInputs;
-    travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix"
-                    "racket2nix-flat-nix" "test" "racket-full.racket2nix" ];
+    travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix" "test" "racket-full.racket2nix" ];
   }

--- a/stage0.nix
+++ b/stage0.nix
@@ -3,16 +3,25 @@
 }:
 
 let
-  inherit (pkgs) nix racket stdenvNoCC;
-  stage0-nix = stdenvNoCC.mkDerivation {
-    name = "racket2nix-stage0.nix";
+inherit (pkgs) nix racket runCommand;
+nix-command = nix;
+bootstrap = name: extraArgs: let
+  nix = runCommand "${name}.nix" {
     src = ./nix;
-    buildInputs = [ nix racket ];
-    phases = "unpackPhase installPhase";
-    installPhase = ''
-      racket -N racket2nix ./racket2nix.rkt --catalog ${catalog} $src > $out
-    '';
-  };
-  stage0 = pkgs.callPackage stage0-nix { inherit racket; };
+    buildInputs = [ nix-command racket ];
+    inherit extraArgs;
+  } ''
+    racket -N racket2nix $src/racket2nix.rkt $extraArgs --catalog ${catalog} $src > $out
+  '';
+  out = (pkgs.callPackage nix {}).overrideAttrs (oldAttrs: {
+    name = "${name}";
+    postInstall = "$out/bin/racket2nix --test";
+    buildInputs = oldAttrs.buildInputs ++ [ nix-command ];
+  });
 in
-stage0 // { nix = stage0-nix; }
+  out // { inherit nix; };
+in
+
+(bootstrap "racket2nix-stage0" "") // {
+  flat = bootstrap "racket2nix-stage0.flat" "--flat";
+}

--- a/stage1.nix
+++ b/stage1.nix
@@ -1,0 +1,48 @@
+{ pkgs ? import ./pkgs {}
+}:
+
+let
+inherit (pkgs) buildEnv buildRacketPackage nix nix-prefetch-git racket2nix-stage0 runCommand;
+
+# Don't just build a flat package, build it with flat racket2nix.
+buildRacketPackageFlat = package: (pkgs.overridePkgs (oldAttrs: {
+  overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix.flat; }) ];
+})).buildRacket { inherit package; flat = true; };
+
+addAttrs = drv: drv.overrideAttrs (oldAttrs: {
+  buildInputs = oldAttrs.buildInputs ++ [ nix verify ];
+  postInstall = "$out/bin/racket2nix --test";
+
+  # We put the deps both in paths and buildInputs, so you can use this either as just
+  # nix-shell -A racket2nix.buildEnv
+  # and get the environment-variable-only environment, or you can use it as
+  # nix-shell -p $(nix-build -A racket2nix.buildEnv)
+  # and get the symlink tree environment
+
+  buildEnv = buildEnv rec {
+    name = "${drv.name}-env";
+    paths = [ nix nix-prefetch-git drv ];
+    buildInputs = paths;
+  };
+});
+
+stage1 = (buildRacketPackage ./nix) // {
+  flat = buildRacketPackageFlat ./nix;
+};
+
+verify = runCommand "verify-stage1.sh" {} ''
+  set -e; set -u
+  diff ${racket2nix-stage0.nix} ${stage1.nix} >> $out
+  diff ${racket2nix-stage0.flat.nix} ${stage1.flat.nix} >> $out
+'';
+
+racket2nix-stage1 = (addAttrs stage1).overrideAttrs (oldAttrs: {
+  name = "racket2nix-stage1";
+}) // {
+  inherit (stage1) nix;
+  flat = (addAttrs stage1.flat).overrideAttrs (oldAttrs: {
+    name = "racket2nix-stage1.flat";
+  }) // { inherit (stage1.flat) nix; };
+};
+in
+racket2nix-stage1

--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -23,15 +23,10 @@ function main() {
 
 function build() {
   local nixpkgs_paths=()
-
-  for path in \
-    $HOME/.nix-defexpr/channel/nixpkgs \
-    /home/travis/.nix-defexpr/channels/nixpkgs \
-    /nix/var/nix/profiles/per-user/root/channels/nixpkgs \
-  ; do
-    [[ -e $path ]] &&
-    nixpkgs_paths+=(-I "$(readlink "$path")")
-  done
+  if local nixpkgs_path=$(nix-instantiate --eval -E 'builtins.toString <nixpkgs>'); then
+    nixpkgs_paths+=( -I nixpkgs="$(eval "readlink $nixpkgs_path")" )
+    echo I read the link and now the parameters are "${nixpkgs_paths[@]}"
+  fi
 
   nix-build --fallback --option restrict-eval true --arg isTravis true \
     "${nixpkgs_paths[@]}" \

--- a/test.nix
+++ b/test.nix
@@ -4,28 +4,19 @@
 
 let it-attrs = integration-test.attrs; in
 let
-  inherit (pkgs) buildRacket racket racket2nix stdenvNoCC;
-  buildRacketAndFlat = package: (buildRacket { inherit package; }) // {
-    flat = buildRacket { inherit package; flat = true; };
-  };
+  inherit (pkgs) buildRacketPackage racket2nix runCommand;
   attrs = rec {
-  racket-doc = buildRacketAndFlat "racket-doc";
-  typed-map-lib = buildRacketAndFlat "typed-map-lib";
-  br-parser-tools-lib = buildRacketAndFlat "br-parser-tools-lib";
+  racket-doc = buildRacketPackage "racket-doc";
+  typed-map-lib = buildRacketPackage "typed-map-lib";
+  br-parser-tools-lib = buildRacketPackage "br-parser-tools-lib";
 
-  light-tests = stdenvNoCC.mkDerivation {
-    name = "light-tests";
+  light-tests = runCommand "light-tests" {
     buildInputs = [ typed-map-lib typed-map-lib.flat br-parser-tools-lib br-parser-tools-lib.flat ] ++
       builtins.attrValues integration-test;
-    phases = "installPhase";
-    installPhase = ''touch $out'';
-  };
-  heavy-tests = stdenvNoCC.mkDerivation {
-    name = "heavy-tests";
+  } ''touch $out'';
+  heavy-tests = runCommand "heavy-tests" {
     buildInputs = [ racket-doc racket-doc.flat ];
-    phases = "installPhase";
-    installPhase = ''touch $out'';
-  };
+  } ''touch $out'';
   integration-test = it-attrs;
 };
 in


### PR DESCRIPTION
The new pkgs construct and a general annoyance with one too many "yeah
I'll get around to that thing" provide an excellent combination for a
major refactoring round.

We have things not making use of neat nixpkgs constructs I didn't know
about half a year ago, and we have things that have grown organically
out of control and are in need of some structure.

We are repeating ourselves all over the place.

Solution: Refactor And Fix All The Things.

 - mkDerivation -> runCommand or buildEnv
 - (buildRacketPackage "yourpackagenamehere").flat
 - stage0 refactor to look more like buildRacket
 - stage1 refactor to use buildRacket
 - pkgs.overridePkgs (after-the-fact overlays!) used by stage1 to get
   a flat stage0 for flat stage1 while still using buildRacket
 - racket2nix.buildEnv
 - clean fix replacing the workaround for nix-build-travis-fold and
   the "access to path ... in restricted mode" issue