### PR TITLE
Problem: No way to tell one-liner to use racket-full

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { system ? builtins.currentSystem
-, pkgs ? import ./pkgs { inherit system; }
+, overlays ? []
+, pkgs ? import ./pkgs { inherit overlays system; }
 , package ? null
 , flat ? false
 , catalog ? ./catalog.rktd


### PR DESCRIPTION
Solution: Allow passing overlays to default.nix.

Want to use full racket?

    nix-build /path/to/racket2nix --argstr package thepackage --arg overlays '[ (self: super: { racket = super.racket-full; }) ]'