### PR TITLE
Problem: Our derivation names may collide with nixpkgs

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -74,6 +74,8 @@ fixedRacketSource = { pathname, sha256 }: pkgs.runCommand (baseNameOf (stripHash
 '';
 
 mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridable (attrs: stdenv.mkDerivation (rec {
+  name = "${racket.name}-${pname}";
+  inherit (attrs) pname;
   buildInputs = [ unzip racket attrs.racketBuildInputs ];
   circularBuildInputsStr = lib.concatStringsSep " " attrs.circularBuildInputs;
   racketBuildInputsStr = lib.concatStringsSep " " attrs.racketBuildInputs;
@@ -284,7 +286,7 @@ EOM
 
 (define derivation-template #<<EOM
 mkRacketDerivation rec {
-  name = "~a";
+  pname = "~a";
 ~a
   racketBuildInputs = [ ~a ];
   circularBuildInputs = [ ~a ];


### PR DESCRIPTION
Case in point: racket2nix itself is a package called `nix`, which
collides with the derivation of the nix package manager itself.

Solution: Prepend `$racket.name` to the package derivation name.

This has the added advantage of also distinguishing racket versions,
and even racket-full vs racket-minimal.

Also it solves another minor issue, which is that of distinguishing
the package derivation from the package source derivation.

Closes #127