### PR TITLE
Problem: catalog-overrides.rkt: Stray lines

### DIFF
--- a/catalog-overrides.rktd
+++ b/catalog-overrides.rktd
@@ -588,8 +588,6 @@
        #hasheq((nix-sha256
                 .
                 "1rm4bm8h04paa23j059w7fak2gim3zkxcq4dy65rq4r6xqyvwdln")
-               (build
-                .
                (dependencies . ("base" "dynext-lib" "make" "rackunit-lib"))
                (authors . ("tonygarnockjones@gmail.com"))
                (description . "ANSI and VT10x escape sequences for Racket.")


### PR DESCRIPTION
There's an incomplete `(build .` in `catalog-overrides.rkt`, stemming from:

71b9f47bda13f5067f32c86ac013228910947ac7
#177

Solution: Remove stray characters.