### PR TITLE
Problem: Our derivations don't respect --cores

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -229,7 +229,7 @@ mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridable (
       for setup_name in $install_names; do
         setup_names+=" ''${setup_name#./}"
       done
-      ${raco} setup --no-user --no-pkg-deps --fail-fast --only --pkgs $setup_names |&
+      ${raco} setup -j $NIX_BUILD_CORES --no-user --no-pkg-deps --fail-fast --only --pkgs $setup_names |&
         sed -ne '/updating info-domain/,$p'
     fi
 


### PR DESCRIPTION
Solution: Send `-j $NIX_BUILD_CORES` to `raco setup`.

 - If your build fails, you can run `nix-build --cores 1 ...` to get
   nice linear output and see exactly where `raco setup` failed.