### PR TITLE
 Problem: Only racket2nix gets a buildEnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ compiled
 /default.nix.in.timestamp
 /pkgs-all
 /result*
+/catalog.rktd.new

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  inherit (pkgs) lib nix racket2nix runCommand;
+  inherit (pkgs) buildEnv lib nix racket2nix runCommand;
   default-catalog = catalog;
 
   attrs = rec {
@@ -17,9 +17,24 @@ let
     } ''
       racket2nix $flatArg --catalog ${catalog} $package > $out
     '';
-    buildRacket = lib.makeOverridable ({ catalog ? default-catalog, flat ? false, package }:
-      let nix = buildRacketNix { inherit catalog flat package; };
-      in pkgs.callPackage nix {} // { inherit nix; } //
+    buildRacket = lib.makeOverridable ({ catalog ? default-catalog, flat ? false, package, attrOverrides ? (oldAttrs: {}) }:
+      let
+        nix = buildRacketNix { inherit catalog flat package; };
+        self = (pkgs.callPackage nix {}).overrideAttrs attrOverrides;
+      in self // {
+        # We put the deps both in paths and buildInputs, so you can use this either as just
+        #     nix-shell -A buildEnv
+        # and get the environment-variable-only environment, or you can use it as
+        #     nix-shell -p $(nix-build -A buildEnv)
+        # and get the symlink tree environment.
+
+        buildEnv = buildEnv rec {
+          name = "${self.pname}-env";
+          buildInputs = [ self ] ++ (self.propagatedBuildInputs or []);
+          paths = buildInputs;
+        };
+        inherit nix;
+      } //
         lib.optionalAttrs (! flat) { flat = buildRacket { inherit catalog package; flat = true; }; }
     );
     buildRacketPackage = package: buildRacket { inherit package; };

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -5,8 +5,9 @@
 }:
 
 let
-  inherit (pkgs) lib nix racket racket2nix runCommand;
+  inherit (pkgs) lib nix racket2nix runCommand;
   default-catalog = catalog;
+
   attrs = rec {
     buildRacketNix = { catalog, flat, package}:
     runCommand "racket-package.nix" {
@@ -18,7 +19,7 @@ let
     '';
     buildRacket = lib.makeOverridable ({ catalog ? default-catalog, flat ? false, package }:
       let nix = buildRacketNix { inherit catalog flat package; };
-      in (pkgs.callPackage nix { inherit racket; }) // { inherit nix; } //
+      in pkgs.callPackage nix {} // { inherit nix; } //
         lib.optionalAttrs (! flat) { flat = buildRacket { inherit catalog package; flat = true; }; }
     );
     buildRacketPackage = package: buildRacket { inherit package; };

--- a/stage1.nix
+++ b/stage1.nix
@@ -15,12 +15,8 @@ attrOverrides = oldAttrs: {
   postInstall = "$out/bin/racket2nix --test";
 };
 
-stage1 = buildRacket { package = ./nix; attrOverrides = (oldAttrs: attrOverrides oldAttrs // {
-  pname = "racket2nix-stage1";
-}); } // {
-  flat = buildRacketFlat { package = ./nix; attrOverrides = (oldAttrs: attrOverrides oldAttrs // {
-    pname = "racket2nix-stage1.flat";
-  }); };
+stage1 = buildRacket { package = ./nix; pname = "racket2nix-stage1"; inherit attrOverrides; } // {
+  flat = buildRacketFlat { package = ./nix; pname = "racket2nix-stage1.flat"; inherit attrOverrides; };
 };
 
 verify = runCommand "verify-stage1.sh" {} ''

--- a/stage1.nix
+++ b/stage1.nix
@@ -2,32 +2,25 @@
 }:
 
 let
-inherit (pkgs) buildEnv buildRacketPackage nix nix-prefetch-git racket2nix-stage0 runCommand;
+inherit (pkgs) buildRacket nix nix-prefetch-git racket2nix-stage0 runCommand;
 
 # Don't just build a flat package, build it with flat racket2nix.
-buildRacketPackageFlat = package: (pkgs.overridePkgs (oldAttrs: {
+buildRacketFlat = { ... }@args: (pkgs.overridePkgs (oldAttrs: {
   overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix.flat; }) ];
-})).buildRacket { inherit package; flat = true; };
+})).buildRacket (args // { flat = true; });
 
-addAttrs = drv: drv.overrideAttrs (oldAttrs: {
-  buildInputs = oldAttrs.buildInputs ++ [ nix verify ];
+attrOverrides = oldAttrs: {
+  buildInputs = oldAttrs.buildInputs ++ [ verify ];
+  propagatedBuildInputs = (oldAttrs.propagatedBuildInputs or []) ++ [ nix.out nix-prefetch-git ];
   postInstall = "$out/bin/racket2nix --test";
+};
 
-  # We put the deps both in paths and buildInputs, so you can use this either as just
-  # nix-shell -A racket2nix.buildEnv
-  # and get the environment-variable-only environment, or you can use it as
-  # nix-shell -p $(nix-build -A racket2nix.buildEnv)
-  # and get the symlink tree environment
-
-  buildEnv = buildEnv rec {
-    name = "${drv.name}-env";
-    paths = [ nix nix-prefetch-git drv ];
-    buildInputs = paths;
-  };
-});
-
-stage1 = (buildRacketPackage ./nix) // {
-  flat = buildRacketPackageFlat ./nix;
+stage1 = buildRacket { package = ./nix; attrOverrides = (oldAttrs: attrOverrides oldAttrs // {
+  pname = "racket2nix-stage1";
+}); } // {
+  flat = buildRacketFlat { package = ./nix; attrOverrides = (oldAttrs: attrOverrides oldAttrs // {
+    pname = "racket2nix-stage1.flat";
+  }); };
 };
 
 verify = runCommand "verify-stage1.sh" {} ''
@@ -36,13 +29,5 @@ verify = runCommand "verify-stage1.sh" {} ''
   diff ${racket2nix-stage0.flat.nix} ${stage1.flat.nix} >> $out
 '';
 
-racket2nix-stage1 = (addAttrs stage1).overrideAttrs (oldAttrs: {
-  name = "racket2nix-stage1";
-}) // {
-  inherit (stage1) nix;
-  flat = (addAttrs stage1.flat).overrideAttrs (oldAttrs: {
-    name = "racket2nix-stage1.flat";
-  }) // { inherit (stage1.flat) nix; };
-};
 in
-racket2nix-stage1
+stage1


### PR DESCRIPTION


Everyone has an interest in being able to just
    nix-shell -A buildEnv --run 'mything'

Solution: Move buildEnv from stage1 to buildRacket.

 - Give buildRacket a new parameter attrOverrides, so that stage1
   can get its deps in there before the extra attrs are added.
 - Give buildRacket a new parameter pname, to override only that attribute, as this reduces complexity in stage1 and allows us better names for `racket-package.nix.drv`.