### PR TITLE
Problem: No API for building catalogs

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -39,6 +39,19 @@ let
         lib.optionalAttrs (! flat) { flat = buildRacket { inherit catalog package; flat = true; }; }
     );
     buildRacketPackage = package: buildRacket { inherit package; };
+    buildRacketCatalog = packages: let
+      buildOneCatalog = package: runCommand "subcatalog.rktd" {
+        buildInputs = [ racket2nix nix ];
+        inherit catalog package packages;
+      } ''
+        racket2nix --export-catalog --no-process-catalog --catalog $catalog $package $packages --export-catalog > $out
+      '';
+    in runCommand "catalog.rktd" {
+      buildInputs = [ racket2nix nix ];
+      catalogs = map buildOneCatalog packages;
+    } ''
+      racket2nix --export-catalog --no-process-catalog $(printf -- '--catalog %s ' $catalogs) > $out
+    '';
   };
 in
 attrs

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,7 +13,7 @@ pkgsFn = args: args.pkgs ((removeAttrs args [ "pkgs" ]) // { overlays = [ (self:
   racket2nix-stage0 = self.callPackage ../stage0.nix {};
   racket2nix-stage1 = self.callPackage ../stage1.nix {};
   racket2nix = self.racket2nix-stage0;
-  inherit (self.callPackage ../build-racket.nix {}) buildRacket buildRacketPackage;
+  inherit (self.callPackage ../build-racket.nix {}) buildRacket buildRacketPackage buildRacketCatalog;
 }; in racket2nix-pkgs // { inherit racket2nix-pkgs; }) ] ++ args.overlays; });
 makeOverridable = g: args: (g (args // { overlays = args.overlays ++ [
   (self: super: { overridePkgs = f: makeOverridable g (args // (f args)); })


### PR DESCRIPTION
When you're in the situation where you have several packages not
published on pkgs.racket-lang, you have to create provisional
catalogs, patch them for internal vs external use, and run update
scripts outside Nix. See fractalide/cardano-wallet for the machinery
required.

Solution: Provide buildRacketCatalog, which takes several packages,
potentially with dependencies among themselves, and merges their
definitions with the default catalog to create a catalog that can
build either one of the packages.

Making one catalog per package and then merging them is a bit clunky,
and the real solution is to implement export of several packages in
racket2nix, but I'd like to kick that can down the road a bit, and
this workaround in Nix was quick and easy.

To be concrete, this is the kind of thing this change enables:

```
buildRacket {
  package = ./mypackage;
  catalog = buildRacketCatalog [
    ./mypackage
    ./myotherpackage
    (import ./mypkgs {}).theirpackage.src
  ];
}
```