### PR TITLE
Problem: Package name not trivially available in derivation

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -249,6 +249,7 @@ mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridable (
   '';
 } // attrs)) suppliedAttrs; in racketDerivation.overrideAttrs (oldAttrs: {
   passthru = oldAttrs.passthru or {} // {
+    inherit (suppliedAttrs) pname;
     inherit racketDerivation;
     overrideRacketDerivation = f: mkRacketDerivation (suppliedAttrs // (f suppliedAttrs));
   };});


### PR DESCRIPTION
The derivation name is now more than just the package name, but the
package name, predictable and by itself, is useful for e.g. filtering
packages.

Solution: Put `pname` in `passthru`.

Relates to #189 , but fractalide will have to be updated to close it.