### PR TITLE
Problem: Not using Racket 7.0

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -12,11 +12,11 @@ attrs = rec {
     SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
     outputHashMode = "flat";
     outputHashAlgo = "sha256";
-    outputHash = "1p8f4yrnv9ny135a41brxh7k740aiz6m41l67bz8ap1rlq2x7pgm";
+    outputHash = "1ckyw31h4mshi72cczvb2n3kgdybjzxlm4acqfriqrzxw3q10w2l";
   } ''
     cd $src
     racket -N dump-catalogs ./dump-catalogs.rkt \
-      https://download.racket-lang.org/releases/6.12/catalog/ > $out
+      https://download.racket-lang.org/releases/7.0/catalog/ > $out
   '';
   liveCatalog = runCommand "live-catalog" {
     src = ./nix;

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -3,8 +3,8 @@ let
   pinnedPkgs = bootPkgs.fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs-channels";
-    rev = "d1ae60cbad7a49874310de91cd17708b042400c8";
-    sha256 = "0a1w4702jlycg2ab87m7n8frjjngf0cis40lyxm3vdwn7p4fxikz";
+    rev = "4477cf04b6779a537cdb5f0bd3dd30e75aeb4a3b";
+    sha256 = "1i39wsfwkvj9yryj8di3jibpdg3b3j86ych7s9rb6z79k08yaaxc";
   };
 in
 import pinnedPkgs


### PR DESCRIPTION
Racket 7.0 is now in nixpkgs-unstable.

Solution: Bump nixpkgs, bump release catalog.