### PR TITLE
Problem: Launcher creation is not pure

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -148,7 +148,7 @@ mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridable (
           (lib-search-dirs . ,lib-dirs)
           (lib-dir . ,(format "~a/lib/racket" out))
           (bin-dir . ,(format "~a/bin" out))
-          (absolute-installation . #t)
+          (absolute-installation? . #t)
           (installation-name . ".")
 
           (links-search-files . ,(share/racket "links.rktd"))


### PR DESCRIPTION
The launcher creation calls (make-relative-path-header), which peeks
at the filesystem for certain tools. How the output looks depends on
what it sees, and varies between sandboxed and non-sandboxed builds.

Solution: Set absolute-install? to #t in config.rktd.

This gets us a plain, hard-coded directory reference for launchers to
look for racket.

Closes #194

Makes any worries in #186 obsolete.