### PR TITLE
Problem: Makefile: release: echo is redundant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ racket2nix:
 
 release:
 	./support/utils/nix-build-travis-fold.sh -I racket2nix=$(PWD) --no-out-link release.nix 2>&1 | sed -e 's/travis_.*\r//'
-	echo
 
 test:
 	nix-build --no-out-link test.nix 2>&1


### PR DESCRIPTION
Now we have sed to remove those pesky carriage returns. And that
`echo` should have been an `@echo` to begin with.

Solution: Remove `echo`.