### PR TITLE
Problem: 'patching script interpreter paths' wrong

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -212,6 +212,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
 
     printf > $env/bin/racket "#!${bash}/bin/bash\nexec ${racket-cmd} \"\$@\"\n"
     chmod 555 $env/bin/racket
+    PATH=$env/bin:$PATH
 
     # install and link us
     install_names=""


### PR DESCRIPTION
.rkt scripts with a shebang for running racket get patched for running
the plain racket binary, instead of the wrapper that sets up the
environment and allows the file to actually run.

Solution: Add the wrapper to PATH when building.

Before:

    $ head -n 1 $(nix-build -A racket2nix.env)/share/racket/pkgs/nix/racket2nix.rkt
    #!/nix/store/gz8l5riy8ppvnqk1vfkan65wwk82pjka-racket-minimal-7.0/bin/racket

After:

    $ head -n 1 $(nix-build -A racket2nix.env)/share/racket/pkgs/nix/racket2nix.rkt
    #!/nix/store/lxsk3qk4f8lrym9c1sxjcxhv3zcjky0d-racket-minimal-7.0-nix-env/bin/racket