### PR TITLE
Problem: integration-tests are simplistic

### DIFF
--- a/integration-tests/a-depends-on-b/info.rkt
+++ b/integration-tests/a-depends-on-b/info.rkt
@@ -1,7 +1,0 @@
-#lang info
-(define version "0.0")
-(define collection "a")
-(define deps '("base" "b-depends-on-c"))
-(define build-deps '())
-(define pkg-desc "Dummy package to validate that depending on circular dependencies works correctly.")
-(define pkg-authors '("claes.wallin@greatsinodevelopment.com"))

--- a/integration-tests/a-depends-on-b/main.rkt
+++ b/integration-tests/a-depends-on-b/main.rkt
@@ -1,7 +1,0 @@
-#lang racket/base
-
-(require b)
-
-(provide (all-defined-out))
-
-(define (dummy) (b-dummy 42))

--- a/integration-tests/b-depends-on-c/info.rkt
+++ b/integration-tests/b-depends-on-c/info.rkt
@@ -1,7 +1,0 @@
-#lang info
-(define version "0.0")
-(define collection "b")
-(define deps '("base" "c-depends-on-b"))
-(define build-deps '())
-(define pkg-desc "Dummy package to validate that depending on circular dependencies works correctly.")
-(define pkg-authors '("claes.wallin@greatsinodevelopment.com"))

--- a/integration-tests/b-depends-on-c/main.rkt
+++ b/integration-tests/b-depends-on-c/main.rkt
@@ -1,7 +1,0 @@
-#lang racket/base
-
-(require c)
-
-(provide (all-defined-out))
-
-(define (b-dummy x) (c-dummy x))

--- a/integration-tests/b-depends-on-c/what-c-needs.rkt
+++ b/integration-tests/b-depends-on-c/what-c-needs.rkt
@@ -1,5 +1,0 @@
-#lang racket/base
-
-(provide (all-defined-out))
-
-(define (b-c-b-dummy x) (printf "What do you get if you multiply six by nine? ~a~n" x))

--- a/integration-tests/c-depends-on-b/info.rkt
+++ b/integration-tests/c-depends-on-b/info.rkt
@@ -1,7 +1,0 @@
-#lang info
-(define version "0.0")
-(define collection "c")
-(define deps '("base" "b-depends-on-c"))
-(define build-deps '())
-(define pkg-desc "Dummy package to validate that depending on circular dependencies works correctly.")
-(define pkg-authors '("claes.wallin@greatsinodevelopment.com"))

--- a/integration-tests/c-depends-on-b/main.rkt
+++ b/integration-tests/c-depends-on-b/main.rkt
@@ -1,7 +1,0 @@
-#lang racket/base
-
-(require b/what-c-needs)
-
-(provide (all-defined-out))
-
-(define (c-dummy x) (b-c-b-dummy x))

--- a/integration-tests/default.nix
+++ b/integration-tests/default.nix
@@ -3,10 +3,85 @@
 
 let
 inherit (pkgs) buildRacket buildRacketCatalog racket racket2nix;
+
+deps = {
+a = [ "b" "c" "f" "g" "n" "o" "s" "y" ];
+b = [ "d" ];
+c = [ "d" ];
+d = [ "a" "e" ];
+e = [  ];
+f = [  ];
+g = [ "h" ];
+h = [ "i" ];
+i = [ "h" "j" ];
+j = [ "a" ];
+k = [ "l" ];
+l = [ "m" "x" ];
+m = [ "l" ];
+n = [ "m" ];
+o = [ "r" ];
+p = [ "q" "r" ];
+q = [ "a" ];
+r = [ "p" ];
+s = [ "t" ];
+t = [ "u" "w" ];
+u = [ "t" "v" ];
+v = [  ];
+w = [ "a" ];
+x = [  ];
+y = [ "z" ];
+z = [ "a" ];
+};
+
+inherit (builtins) concatStringsSep;
+
+nameDepsToDrv = name: deps: pkgs.runCommand name {
+} ''
+  mkdir $out
+  cat > $out/info.rkt <<EOF
+#lang info
+(define version "0.0")
+(define collection "${name}")
+(define deps '("base" ${concatStringsSep " " (map (dep: "\"${dep}\"") deps)}))
+(define build-deps '())
+(define pkg-desc "Dummy package to validate that depending on circular dependencies works correctly.")
+(define pkg-authors '("claes.wallin@greatsinodevelopment.com"))
+(define racket-launcher-names '("${name}"))
+(define racket-launcher-libraries '("main.rkt"))
+EOF
+  cat > $out/main.rkt <<EOF
+#lang racket
+
+${concatStringsSep "\n" (map (dep: "(require ${dep}/terminal)") deps)}
+
+(provide (all-defined-out))
+
+(define (${name}) (string-append
+${concatStringsSep "\n" (map (dep: "  (${dep}-terminal)") deps)}))
+
+(module+ main
+  (displayln (${name})))
+EOF
+
+  cat > $out/terminal.rkt <<EOF
+#lang racket/base
+
+(provide (all-defined-out))
+
+(define (${name}-terminal)
+  "${name}")
+EOF
+'';
+
+inherit (pkgs.lib) mapAttrs;
+
+packages = mapAttrs nameDepsToDrv deps;
+
 attrs = rec {
-  catalog = buildRacketCatalog [ ./a-depends-on-b ./b-depends-on-c ./c-depends-on-b ];
-  circular-subdeps = buildRacket { package = "a-depends-on-b"; inherit catalog; flat = false; };
-  circular-subdeps-flat = circular-subdeps.override { flat = true; };
+  catalog = buildRacketCatalog [ (builtins.attrValues packages) ];
+  circular-subdeps = map (p: buildRacket { package = packages.${p}; inherit catalog; flat = false; })
+                         [ "a" "k" ];
+  circular-subdeps-flat = map (p: p.override { flat = true; }) circular-subdeps;
 }; in
 
 attrs // { inherit attrs; }

--- a/release.nix
+++ b/release.nix
@@ -15,7 +15,9 @@ let
     };
     pkgs-all = pkgs.callPackage (racket2nixPath "catalog.nix") {};
     racket2nix = pkgs.callPackage <racket2nix> {};
-    test = pkgs.callPackage (racket2nixPath "test.nix") {};
+    tests = {
+      inherit (pkgs.callPackage (racket2nixPath "test.nix") {}) light-tests heavy-tests;
+    };
   };
 in
   (genJobs (pkgs {})) //
@@ -28,6 +30,6 @@ in
     racket-full = genJobs (pkgs { overlays = [ (self: super: { racket = self.racket-full; }) ]; });
   } // lib.optionalAttrs isTravis {
     stage0-nix-prerequisites = (pkgs {}).racket2nix-stage0.buildInputs;
-    travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix" "test" "racket-full.racket2nix"
-                    "api.override-racket-derivation" ];
+    travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix" "tests.light-tests"
+                    "racket-full.racket2nix" "api.override-racket-derivation" ];
   }


### PR DESCRIPTION
Solution: Convert package tree unit tests to integration tests.

Instead of the manually written packages, generate racket packages
with the full range of complications:
 - Long circles
 - Circles within circles
 - Independent circles depended on by other circles

This would have caught a thing or two that I encountered while
working on the new circle resolver (while the unit tests had not yet
been adapted).

For now, just verify that the packages build. The code in the packages
expresses the dependencies, so any missing dependency will cause a
compilation error.