### PR TITLE
Problem: Our racket-minimal-7.0 is a 6.12 disguised as 7.0

### DIFF
--- a/racket-minimal/default.nix
+++ b/racket-minimal/default.nix
@@ -7,7 +7,7 @@ racket-full.overrideAttrs (oldAttrs: rec {
   name = "racket-minimal-${oldAttrs.version}";
   src = oldAttrs.src.override {
     inherit name;
-    sha256 = "0c565jy2y3gjl5lncd5adjsrj8c24p4i062kphv26ni5q1nn5ip5";
+    sha256 = "0ivpr1a2w1ln1lx91q11rj9wp3rbfq33acrz2gxxvd80qqaq3zyh";
   };
 
   meta = oldAttrs.meta // {


### PR DESCRIPTION
The basename of the source is racket-minimal-src.tgz, the version is
only reflected in the directory name.

We forgot to update the sha256 or the fixed-output derivation, so it
just used the old source under a new derivation name.

Solution: Update the sha256.

Nixpkgs has this issue too on nixpkgs-unstable. Fixed on master.