### PR TITLE
Problem: mkRacketDerivation: Requires packages to have a src

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -89,8 +89,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   racketConfigBuildInputs = builtins.filter (input: ! builtins.elem input reverseCircularBuildInputs) racketBuildInputs;
   racketConfigBuildInputsStr = lib.concatStringsSep " " (map (drv: drv.env) racketConfigBuildInputs);
   reverseCircularBuildInputs = attrs.reverseCircularBuildInputs or [];
-  srcs = [ attrs.src ]
-           ++ attrs.extraSrcs or (map (input: input.src) reverseCircularBuildInputs);
+  src = attrs.src or null;
+  srcs = [ src ] ++ attrs.extraSrcs or (map (input: input.src) reverseCircularBuildInputs);
   inherit racket;
   outputs = [ "out" "env" ];
 


### PR DESCRIPTION
This won't hold for synthesized packages representing cycles
("reified cycles").

Solution: Check for a `src` attribute, and just use null otherwise.

We could have used no src attribute at all, but flat builds expect
all transitive dependencies to have a src attribute.