### PR TITLE
Problem: buildRacket: attrOverrides ignored

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -31,8 +31,9 @@ let
           in
             apply-overlays rpkgs overlays;
         in
-          racket-packages."${pname}".overrideAttrs (oldAttrs:
-            { passthru = oldAttrs.passthru or {} // { inherit racket-packages; }; });
+          (racket-packages."${pname}".overrideAttrs (oldAttrs: {
+            passthru = oldAttrs.passthru or {} // { inherit racket-packages; };
+          })).overrideAttrs attrOverrides;
       in self // {
         # We put the deps both in paths and buildInputs, so you can use this either as just
         #     nix-shell -A buildEnv


### PR DESCRIPTION
stage1.nix uses it to add deps etc to the stage1 derivations.

Solution: overrideAttrs attrOverrides