### PR TITLE
Problem: discover-path-sha256: base16

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -394,7 +394,7 @@ EOM
     (unless nh-path
       (eprintf "ERROR: nix-hash not found on PATH~n")
       (exit 1))
-    (unless (equal? 0 (system*/exit-code nh-path "--type" "sha256" pathname))
+    (unless (equal? 0 (system*/exit-code nh-path "--base32" "--type" "sha256" pathname))
             (exit 1))))))
 
 (define discover-store-path


### PR DESCRIPTION
The hash looks unfamiliar, because base32 is the encoding usually used
when writing nix derivations.

Solution: Call nix-hash with --base32.