### PR TITLE
Problem: build-racket: The fixed-output derivation fails

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -20,7 +20,7 @@ let
           inherit package; outputHashMode = "recursive"; outputHashAlgo = "sha256";
           outputHash = builtins.readFile sha256;
         } ''
-          cp -a $path $out
+          cp -a $package $out
         '';
       in runCommand "${pname}.nix" {
         buildInputs = [ racket2nix nix ];


### PR DESCRIPTION
Solution: Refer to the correct variable.

The problem was disguised by caching of the derivation.