### PR TITLE
Problem: One-liner: catalog packages don't get the overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,6 +12,8 @@ let
   };
 in
 if package == null then (attrs.racket2nix // attrs) else
-if builtins.isString package then (pkgs.callPackage ./racket-packages.nix {})."${package}"
+if builtins.isString package then
+  ((pkgs.callPackage ./racket-packages.nix {}).extend
+    (import ./build-racket-default-overlay.nix))."${package}"
 else buildThinRacket ({ inherit package; } //
   lib.optionalAttrs (builtins.isString pname) { inherit pname; })


### PR DESCRIPTION
    $ nix-build --argstr package drracket
    include-bitmap: could not load #<path:/nix/store/s9hpq7xpvdx6987hqri2awbc041pmxcr-racket-minimal-7.0-gui-lib-env/share/racket/pkgs/gui-lib/icons/break.png>: with-input-from-file: cannot open input file
      path: /nix/store/s9hpq7xpvdx6987hqri2awbc041pmxcr-racket-minimal-7.0-gui-lib-env/share/racket/pkgs/gui-lib/icons/break.png
      system error: No such file or directory; errno=2

That issue was fixed in the overlay, but it doesn't get applied.

Solution: Apply default overlay in the string case of the one-liner.