### PR TITLE
Problem: darwin: argument list limits

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -216,13 +216,13 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     for depEnv in $racketConfigBuildInputsStr; do
       if ( shopt -s nullglob; pkgs=($depEnv/share/racket/pkgs/*/); (( ''${#pkgs[@]} > 0 )) ); then
         cp -frs $depEnv/share/racket/pkgs/*/ $env/share/racket/pkgs/
-        find $env/share/racket/pkgs -type d -exec chmod 755 {} +
+        find $env/share/racket/pkgs -type d -print0 | xargs -0 chmod 755
       fi
     done
 
     cp -rs $racket/lib/racket $env/lib/racket
     ln -s $racket/include/racket $env/share/racket/include
-    find $env/share/racket/collects $env/lib/racket -type d -exec chmod 755 {} +
+    find $env/share/racket/collects $env/lib/racket -type d -print0 | xargs -0 chmod 755
 
     printf > $env/bin/racket "#!${bash}/bin/bash\nexec ${racket-cmd} \"\$@\"\n"
     rm -f $env/lib/racket/gracket

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -195,13 +195,13 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     for depEnv in $racketConfigBuildInputsStr; do
       if ( shopt -s nullglob; pkgs=($depEnv/share/racket/pkgs/*/); (( ''${#pkgs[@]} > 0 )) ); then
         cp -frs $depEnv/share/racket/pkgs/*/ $env/share/racket/pkgs/
-        find $env/share/racket/pkgs -type d -exec chmod 755 {} +
+        find $env/share/racket/pkgs -type d -print0 | xargs -0 chmod 755
       fi
     done
 
     cp -rs $racket/lib/racket $env/lib/racket
     ln -s $racket/include/racket $env/share/racket/include
-    find $env/share/racket/collects $env/lib/racket -type d -exec chmod 755 {} +
+    find $env/share/racket/collects $env/lib/racket -type d -print0 | xargs -0 chmod 755
 
     printf > $env/bin/racket "#!${bash}/bin/bash\nexec ${racket-cmd} \"\$@\"\n"
     rm -f $env/lib/racket/gracket


### PR DESCRIPTION
    /nix/store/jkb56ipz7yckrw7imqqfmjjjp90pvs3r-racket-minimal-7.0/bin/racket -G /nix/store/9h5c1qgxkkjj2l7jkld3ijas39sy4xyf-racket-minimal-7.0-fractalide-env/etc/racket -U -X /nix/store/9h5c1qgxkkjj2l7jkld3ijas39sy4xyf-racket-minimal-7.0-fractalide-env/share/racket/collects
    find: 'chmod': Argument list too long

Supposedly find splits the arguments into several calls so that this
should not happen. Apparently that's not reliable.

Solution: Use xargs instead.