### PR TITLE
Problem: nix-instantiate cannot run in the sandbox

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -407,18 +407,7 @@ EOM
 (define discover-store-path
   (let ([store-path #f])
     (lambda ()
-      (cond
-        [store-path store-path]
-        [else
-         (define store-path-string (with-output-to-string (lambda ()
-           (define ni-path (find-executable-path "nix-instantiate"))
-           (unless ni-path
-             (eprintf "ERROR: nix-instantiate not found on PATH~n")
-             (exit 1))
-           (unless (equal? 0 (system*/exit-code ni-path "--eval" "-E" "builtins.storeDir"))
-                   (exit 1)))))
-         (set! store-path (with-input-from-string store-path-string read-json))
-         store-path]))))
+      (set! store-path "/nix/store"))))
 
 (define (strip-store-prefix pathname)
   (define store-path (discover-store-path))


### PR DESCRIPTION
Our method for finding out whether racket2nix is running inside a Nix
derivation (i.e. called from buildRacket) ironically cannot run inside
a Nix derivation, if the sandbox is enabled.

    building '/nix/store/bksdhdyj4hw5ply332zypxmf8rxy9dik-racket-package.nix.drv'...
    error: creating directory '/nix/var': Permission denied
    builder for '/nix/store/bksdhdyj4hw5ply332zypxmf8rxy9dik-racket-package.nix.drv' failed with exit code 1

What it really wants to find out is whether its inputs are in the Nix
store and need to be wrapped in a fixed-output derivation to pass
strict evaluation.

Solution: For now, hard-code the store path as '/nix/store'.

Honestly, it not being '/nix/store' is an extreme corner case that may
not even work. It just didn't feel right to hard-code it.

Closes #226