### PR TITLE
Problem: nix-instantiate cannot run in the sandbox

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -405,7 +405,7 @@ EOM
             (exit 1))))))
 
 (define (store-basename pathname)
-  (third (regexp-match #px"^.*/([a-z0-9]{32}-)?([^/]*)$" pathname)))
+  (third (regexp-match #px"^.*/([a-df-np-sv-z0-9]{32}-)?([^/]*)$" pathname)))
 
 (define (generate-noop-fixed-output-src pathname)
   (format noop-fixed-output-template pathname (discover-path-sha256 pathname)))

--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -404,18 +404,8 @@ EOM
     (unless (equal? 0 (system*/exit-code nh-path "--base32" "--type" "sha256" pathname))
             (exit 1))))))
 
-(define (discover-store-path) "/nix/store")
-
-(define (strip-store-prefix pathname)
-  (define store-path (discover-store-path))
-  (cond [(string-prefix? pathname store-path)
-         (substring pathname (+ (string-length store-path) 34))]
-        [else pathname]))
-
-(define (generate-local-file-src pathname)
-  (cond [(string-prefix? pathname (discover-store-path))
-         (generate-noop-fixed-output-src pathname)]
-        [else (format local-file-template pathname)]))
+(define (store-basename pathname)
+  (third (regexp-match #px"^.*/([a-z0-9]{32}-)?([^/]*)$" pathname)))
 
 (define (generate-noop-fixed-output-src pathname)
   (format noop-fixed-output-template pathname (discover-path-sha256 pathname)))
@@ -483,7 +473,7 @@ EOM
       [(or (string-prefix? url "http://") (string-prefix? url "https://"))
        (format fetchurl-template url sha1)]
       [else
-       (generate-local-file-src url)]))
+       (generate-noop-fixed-output-src url)]))
   (define srcs
     (cond
       [(pair? reverse-circular-build-inputs)
@@ -903,7 +893,7 @@ EOM
 
   (define package-names (map (lambda (package-name-or-path) (cond
     [(string-contains? package-name-or-path "/")
-     (define name (string-replace (strip-store-prefix package-name-or-path) #rx".*/" ""))
+     (define name (store-basename package-name-or-path))
      (define path package-name-or-path)
      (hash-set!
        pkg-details name

--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -404,21 +404,7 @@ EOM
     (unless (equal? 0 (system*/exit-code nh-path "--base32" "--type" "sha256" pathname))
             (exit 1))))))
 
-(define discover-store-path
-  (let ([store-path #f])
-    (lambda ()
-      (cond
-        [store-path store-path]
-        [else
-         (define store-path-string (with-output-to-string (lambda ()
-           (define ni-path (find-executable-path "nix-instantiate"))
-           (unless ni-path
-             (eprintf "ERROR: nix-instantiate not found on PATH~n")
-             (exit 1))
-           (unless (equal? 0 (system*/exit-code ni-path "--eval" "-E" "builtins.storeDir"))
-                   (exit 1)))))
-         (set! store-path (with-input-from-string store-path-string read-json))
-         store-path]))))
+(define (discover-store-path) "/nix/store")
 
 (define (strip-store-prefix pathname)
   (define store-path (discover-store-path))


### PR DESCRIPTION
Our method for finding out whether racket2nix is running inside a Nix
derivation (i.e. called from buildRacket) ironically cannot run inside
a Nix derivation, if the sandbox is enabled.

    building '/nix/store/bksdhdyj4hw5ply332zypxmf8rxy9dik-racket-package.nix.drv'...
    error: creating directory '/nix/var': Permission denied
    builder for '/nix/store/bksdhdyj4hw5ply332zypxmf8rxy9dik-racket-package.nix.drv' failed with exit code 1

What it really wants to find out is whether its inputs are in the Nix
store and need to be wrapped in a fixed-output derivation to pass
strict evaluation.

Solution: For now, hard-code the store path as '/nix/store'.

Honestly, it not being '/nix/store' is an extreme corner case that may
not even work. It just didn't feel right to hard-code it.

Closes #226