### PR TITLE
Problem: make release: Does not work if on a symlink path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ racket2nix:
 	nix-build --no-out-link
 
 release:
-	./support/utils/nix-build-travis-fold.sh -I racket2nix=$(PWD) --no-out-link release.nix 2>&1 | sed -e 's/travis_.*\r//'
+	./support/utils/nix-build-travis-fold.sh -I racket2nix=$(shell pwd | xargs readlink -e) --no-out-link release.nix 2>&1 | sed -e 's/travis_.*\r//'
 
 test:
 	nix-build --no-out-link test.nix 2>&1


### PR DESCRIPTION
Nix canonicalizes the path to release.nix and complains that it cannot
be read in strict mode.

Solution: Canonicalize the path in the nix-build -I parameter.