### PR TITLE
Problem: mergedUnfilteredCatalog: SSL_CERT_FILE warning

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -35,6 +35,7 @@ attrs = rec {
     src = ./nix;
     inherit liveCatalog overrides releaseCatalog;
     buildInputs = [ racket ];
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   } ''
     cd $src
     racket -N export-catalog ./racket2nix.rkt \


### PR DESCRIPTION
    openssl: x509-root-sources: cert sources do not exist: "/no-cert-file.crt", "/nix/store/n5k0bwl54gnpdhv24rk2l5s9gs4x8f2j-openssl-1.0.2p/etc/ssl/certs"; override using SSL_CERT_FILE, SSL_CERT_DIR

We do not actually access the network in this derivation, but someone
might be put on the wrong trail by the warning message.

Solution: Silence the warning by setting SSL_CERT_FILE.