### PR TITLE
Problem: nix-build-travis-fold: Obsolete debug output

### DIFF
--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -25,7 +25,6 @@ function build() {
   local nixpkgs_paths=()
   if local nixpkgs_path=$(nix-instantiate --eval -E 'builtins.toString <nixpkgs>'); then
     nixpkgs_paths+=( -I nixpkgs="$(eval "readlink $nixpkgs_path")" )
-    echo I read the link and now the parameters are "${nixpkgs_paths[@]}"
   fi
 
   nix-build --fallback --option restrict-eval true --arg isTravis true \


### PR DESCRIPTION
    I read the link and now the parameters are -I nixpkgs=/nix/store/y59cw26mvxrkn9qjv1dc5lzxkwjgpdxk-nixpkgs-19.03pre151875.7c1b85cf6de/nixpkgs

This was introduced in #170 (cleanup), commit:
1e321dda94cd2c2f053d35a9c50e6b3269e04daa

Solution: Remove it.