### PR TITLE
 Problem: full-racket heavy-tests fails

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -4,7 +4,6 @@
 
 let
   inherit (pkgs {}) lib buildRacketPackage;
-  racket2nixPath = relPath: "${builtins.toString <racket2nix>}/${relPath}";
 
   genJobs = pkgs: rec {
     api = {
@@ -17,10 +16,10 @@ let
         path = pkgs.callPackage ./. { package = ./nix; };
       };
     };
-    pkgs-all = pkgs.callPackage (racket2nixPath "catalog.nix") {};
+    pkgs-all = pkgs.callPackage <racket2nix/catalog.nix> {};
     racket2nix = pkgs.callPackage <racket2nix> {};
     tests = {
-      inherit (pkgs.callPackage (racket2nixPath "test.nix") {}) light-tests heavy-tests;
+      inherit (pkgs.callPackage <racket2nix/test.nix> {}) light-tests heavy-tests;
     };
   };
 in

--- a/release.nix
+++ b/release.nix
@@ -19,7 +19,9 @@ let
     pkgs-all = pkgs.callPackage <racket2nix/catalog.nix> {};
     racket2nix = pkgs.callPackage <racket2nix> {};
     tests = {
-      inherit (pkgs.callPackage <racket2nix/test.nix> {}) light-tests heavy-tests;
+      inherit (pkgs.callPackage <racket2nix/test.nix> {}) light-tests;
+    } // lib.optionalAttrs ((builtins.match ".*racket-minimal.*" pkgs.racket.name) != null) {
+      inherit (pkgs.callPackage <racket2nix/test.nix> {}) heavy-tests;
     };
   };
 in


### PR DESCRIPTION
    <3>raco setup: docs failure: make-directory: cannot make directory
    <3>  path: /homeless-shelter/
    <3>  system error: Permission denied; errno=13

We don't know why it differs from racket-minimal, but we don't care.

Solution: Remove heavy-tests from full-racket.

I.e., only add it when racket derivation is named racket-minimal.