### PR TITLE
Problem: Error messages about SSL certificates

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -1,4 +1,5 @@
 { pkgs ? import ./pkgs {}
+, cacert ? pkgs.cacert
 , catalog ? ./catalog.rktd
 , racket-package-overlays ? [ (import ./build-racket-default-overlay.nix) ]
 , racket-packages ? pkgs.callPackage ./racket-packages.nix {}
@@ -23,7 +24,7 @@ let
           cp -a $package $out
         '';
       in runCommand "${pname}.nix" {
-        buildInputs = [ racket2nix nix ];
+        buildInputs = [ cacert racket2nix nix ];
         inherit path;
       } ''
         racket2nix --thin $path > $out
@@ -53,7 +54,7 @@ let
     buildRacketNix = { catalog, flat, package, pname ? "racket-package" }:
     runCommand "${pname}.nix" {
       inherit package;
-      buildInputs = [ racket2nix nix ];
+      buildInputs = [ cacert racket2nix nix ];
       flatArg = lib.optionalString flat "--flat";
     } ''
       racket2nix $flatArg --catalog ${catalog} $package > $out
@@ -89,13 +90,13 @@ let
     buildRacketPackage = package: buildRacket { inherit package; };
     buildRacketCatalog = packages: let
       buildOneCatalog = package: runCommand "subcatalog.rktd" {
-        buildInputs = [ racket2nix nix ];
+        buildInputs = [ cacert racket2nix nix ];
         inherit catalog package packages;
       } ''
         racket2nix --export-catalog --no-process-catalog --catalog $catalog $package $packages --export-catalog > $out
       '';
     in runCommand "catalog.rktd" {
-      buildInputs = [ racket2nix nix ];
+      buildInputs = [ cacert racket2nix nix ];
       catalogs = map buildOneCatalog packages;
     } ''
       racket2nix --export-catalog --no-process-catalog $(printf -- '--catalog %s ' $catalogs) > $out

--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -22,6 +22,7 @@
 { pkgs ? import <nixpkgs> {}
 , stdenv ? pkgs.stdenv
 , lib ? stdenv.lib
+, cacert ? pkgs.cacert
 , fetchurl ? pkgs.fetchurl
 , fetchgit ? pkgs.fetchgit
 , racket ? pkgs.racket-minimal
@@ -85,7 +86,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   name = "${racket.name}-${pname}";
   inherit (attrs) pname;
   racketBuildInputs = attrs.racketBuildInputs or [] ++ self.lib.resolveThinInputs attrs.racketThinBuildInputs or [];
-  buildInputs = [ unzip racket ] ++ racketBuildInputs;
+  buildInputs = [ cacert unzip racket ] ++ racketBuildInputs;
   circularBuildInputs = attrs.circularBuildInputs or [];
   circularBuildInputsStr = lib.concatStringsSep " " circularBuildInputs;
   racketBuildInputsStr = lib.concatStringsSep " " racketBuildInputs;

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {}
 , stdenv ? pkgs.stdenv
 , lib ? stdenv.lib
+, cacert ? pkgs.cacert
 , fetchurl ? pkgs.fetchurl
 , fetchgit ? pkgs.fetchgit
 , racket ? pkgs.racket-minimal
@@ -64,7 +65,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   name = "${racket.name}-${pname}";
   inherit (attrs) pname;
   racketBuildInputs = attrs.racketBuildInputs or [] ++ self.lib.resolveThinInputs attrs.racketThinBuildInputs or [];
-  buildInputs = [ unzip racket ] ++ racketBuildInputs;
+  buildInputs = [ cacert unzip racket ] ++ racketBuildInputs;
   circularBuildInputs = attrs.circularBuildInputs or [];
   circularBuildInputsStr = lib.concatStringsSep " " circularBuildInputs;
   racketBuildInputsStr = lib.concatStringsSep " " racketBuildInputs;

--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,6 @@
 { isTravis ? false
 , pkgs ? import ./pkgs
+, cacert ? (pkgs {}).cacert
 }:
 
 let
@@ -30,7 +31,7 @@ in
     racket-packages-updated = (pkgs {}).runCommand "racket-packages-updated" rec {
       src = <racket2nix>;
       inherit (pkgs {}) racket2nix;
-      buildInputs = [ racket2nix ];
+      buildInputs = [ cacert racket2nix ];
     } ''
       set -e; set -u
       racket2nix --catalog $src/catalog.rktd > racket-packages.nix

--- a/stage0.nix
+++ b/stage0.nix
@@ -1,4 +1,5 @@
 { pkgs ? import ./pkgs {}
+, cacert ? pkgs.cacert
 , catalog ? ./catalog.rktd
 }:
 
@@ -8,7 +9,7 @@ nix-command = nix;
 bootstrap = name: extraArgs: let
   nix = runCommand "${name}.nix" {
     src = ./nix;
-    buildInputs = [ nix-command racket ];
+    buildInputs = [ cacert nix-command racket ];
     inherit extraArgs;
   } ''
     racket -N racket2nix $src/racket2nix.rkt $extraArgs --catalog ${catalog} $src > $out

--- a/stage1.nix
+++ b/stage1.nix
@@ -1,4 +1,5 @@
 { pkgs ? import ./pkgs {}
+, cacert ? pkgs.cacert
 }:
 
 let
@@ -24,7 +25,9 @@ stage1 = buildRacket { package = ./nix; pname = "racket2nix-stage1"; inherit att
   thin = buildThin { package = ./nix; inherit attrOverrides; };
 };
 
-verify = runCommand "verify-stage1.sh" {} ''
+verify = runCommand "verify-stage1.sh" {
+  buildInputs = [ cacert ];
+} ''
   set -e; set -u
   diff ${racket2nix-stage0.nix} ${stage1.nix} >> $out
   diff ${racket2nix-stage0.flat.nix} ${stage1.flat.nix} >> $out


### PR DESCRIPTION
    openssl: x509-root-sources: cert sources do not exist: /no-cert-file.crt, /nix/store/nlb8hykwq7jc4vpnda39civ9cvrb7ymq-openssl-1.0.2p/etc/ssl/certs; override using SSL_CERT_FILE, SSL_CERT_DIR

It's only an annoyance -- we do not perform any network operations --
but it's the typical kind of warning message that might take someone
on a wild goose chase while troubleshooting.

Solution: Add `cacert` to the `buildInputs` of things running racket.

Allowing `cacert` to manipulate `SSL_CERT_FILE` is cleaner than
manipulating the variable directly. Modify the derivations that do.