### PR TITLE
Problem: bump-release-catalog uses system racket

### DIFF
--- a/bump-release-catalog.sh
+++ b/bump-release-catalog.sh
@@ -1,5 +1,4 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -p bash nix racket-minimal -i bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 
@@ -14,7 +13,7 @@ version=$(eval echo $(nix-instantiate --eval -E 'with import ./pkgs {}; racket-f
 
 url=https://download.racket-lang.org/releases/$version/catalog/
 hash=$(nix-hash --type sha256 --base32 --flat <(
-  racket -N dump-catalogs nix/dump-catalogs.rkt $url))
+  nix-shell -E 'with import ./pkgs {}; [ racket ]' --run "racket -N dump-catalogs nix/dump-catalogs.rkt $url"))
 
 cat > release-catalog.json.new <<EOF
 {


### PR DESCRIPTION
We should use the racket the catalog is for.

Solution: Use nix-shell inside the script instead of as interpreter.

We cannot just skip using racket, as we did in #242 with the live
catalog, because the release catalog uses relative paths and we want
racket to sort that out for us.