### PR TITLE
Problem: patchPhase ignores pre/postPatch

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -128,7 +128,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     runHook postUnpack
   '';
 
-  patchPhase = ''
+  postPatch = ''
     if [ -d racket-index ]; then
         ( cd racket-index && patch -p3 < ${racketIndexPatch} )
     fi

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -107,7 +107,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     runHook postUnpack
   '';
 
-  patchPhase = ''
+  postPatch = ''
     if [ -d racket-index ]; then
         ( cd racket-index && patch -p3 < ${racketIndexPatch} )
     fi


### PR DESCRIPTION
Solution: Move the racket-index fix to postPatch.

This was patchPhase is intact, and users can override postPatch.

The racket-index patch should probably be moved out to default
overrides, but this is the minimal fix for the issue at hand.