### PR TITLE
 Problem: No GitLab CI support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+nix:
+  image: nixos/nix:latest
+  script:
+   - ./support/utils/setup-hydra.fractalide.com.sh
+   - ./release.sh

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell --quiet -i bash -p bash
 
 set -euo pipefail
 


### PR DESCRIPTION


We do have a mirror repo on gitlab.com. It's nice if anyone forking
there gets feedback that Just Works, before even submitting a PR.

Also, fractalide/fractalide#362 .

Solution: Create .gitlab-ci.yml

There isn't much of anything to maintain, and it doesn't interfere
with anything else.

Thanks:
https://medium.com/plapadoo/using-nix-and-ci-for-great-good-8a9162fed313