### PR TITLE
 Problem: racket-packages.nix shortcut only in default.nix

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -62,10 +62,11 @@ let
     buildRacket = lib.makeOverridable ({ catalog ? default.catalog, flat ? false, package, pname ? false,
                                          attrOverrides ? (oldAttrs: {}), overlays ? default.racket-package-overlays }:
       let
-        nix = buildRacketNix { inherit catalog flat package; } // lib.optionalAttrs (builtins.isString pname) { inherit pname; };
+        nix = if builtins.isString package then null else
+          buildRacketNix { inherit catalog flat package; } // lib.optionalAttrs (builtins.isString pname) { inherit pname; };
         self = let
-          pname = ((pkgs.callPackage nix {}).overrideAttrs attrOverrides).pname;
-          rpkgs = (pkgs.callPackage nix {}).racket-packages;
+          pname = if builtins.isString package then package else ((pkgs.callPackage nix {}).overrideAttrs attrOverrides).pname;
+          rpkgs = if builtins.isString package then default.racket-packages else (pkgs.callPackage nix {}).racket-packages;
           racket-packages = apply-overlays rpkgs overlays;
         in
           (racket-packages."${pname}".overrideAttrs (oldAttrs: {

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -59,14 +59,16 @@ let
     } ''
       racket2nix $flatArg --catalog ${catalog} $package > $out
     '';
-    buildRacket = lib.makeOverridable ({ catalog ? default.catalog, flat ? false, package, pname ? false,
-                                         attrOverrides ? (oldAttrs: {}), overlays ? default.racket-package-overlays }:
+    buildRacket = lib.makeOverridable ({ catalog ? default.catalog, flat ? false, package, pname ? false
+                                       , attrOverrides ? (oldAttrs: {}), overlays ? default.racket-package-overlays
+                                       , buildNix ? !(builtins.isString package) || flat
+                                       }:
       let
-        nix = if builtins.isString package then null else
+        nix = if !buildNix then null else
           buildRacketNix { inherit catalog flat package; } // lib.optionalAttrs (builtins.isString pname) { inherit pname; };
         self = let
-          pname = if builtins.isString package then package else ((pkgs.callPackage nix {}).overrideAttrs attrOverrides).pname;
-          rpkgs = if builtins.isString package then default.racket-packages else (pkgs.callPackage nix {}).racket-packages;
+          pname = if buildNix then ((pkgs.callPackage nix {}).overrideAttrs attrOverrides).pname else package;
+          rpkgs = if buildNix then (pkgs.callPackage nix {}).racket-packages else default.racket-packages;
           racket-packages = apply-overlays rpkgs overlays;
         in
           (racket-packages."${pname}".overrideAttrs (oldAttrs: {

--- a/default.nix
+++ b/default.nix
@@ -6,14 +6,12 @@
 }:
 
 let
-  inherit (pkgs) buildThinRacket lib racket2nix-stage1;
+  inherit (pkgs) buildRacketPackage buildThinRacket lib racket2nix-stage1;
   attrs = pkgs // {
     racket2nix = racket2nix-stage1;
   };
 in
-if package == null then (attrs.racket2nix // attrs) else
-if builtins.isString package then
-  ((pkgs.callPackage ./racket-packages.nix {}).extend
-    (import ./build-racket-default-overlay.nix))."${package}"
+if package == null then (attrs.racket2nix // attrs)
+else if builtins.isString package then buildRacketPackage package
 else buildThinRacket ({ inherit package; } //
   lib.optionalAttrs (builtins.isString pname) { inherit pname; })

--- a/test.nix
+++ b/test.nix
@@ -4,10 +4,10 @@
 
 let it-attrs = integration-tests.attrs; in
 let
-  inherit (pkgs) buildRacketPackage racket2nix runCommand;
+  inherit (pkgs) buildRacket buildRacketPackage racket2nix runCommand;
   attrs = rec {
   racket-doc = buildRacketPackage "racket-doc";
-  typed-map-lib = buildRacketPackage "typed-map-lib";
+  typed-map-lib = buildRacket { package = "typed-map-lib"; buildNix = true; };
   br-parser-tools-lib = buildRacketPackage "br-parser-tools-lib";
 
   light-tests = runCommand "light-tests" {


### PR DESCRIPTION
This makes it a bit obscure to use from e.g. test.nix.

We want to use racket-packages.nix to get the full catalog
and not only the subset of packages in the transitive dependencies,
because the #251 installCheckPhase will want compiler-lib to be
available when building e.g. br-parser-tools-lib.

Also regenerating the Nix expression is unnecessary work.

Solution: Put the functionality in buildRacket instead.

Make default.nix an ever thinner wrapper around build(Thin)Racket.