### PR TITLE
 Problem: No general mechanism for running package tests

### DIFF
--- a/build-racket-default-overlay.nix
+++ b/build-racket-default-overlay.nix
@@ -20,4 +20,7 @@ lib.optionalAttrs (super ? "compatibility+compatibility-doc+data-doc+db-doc+dist
   buildInputs = oldAttrs.buildInputs or [] ++ builtins.attrValues {
     inherit (self.pkgs) glib cairo fontconfig gmp gtk3 gsettings-desktop-schemas libedit libjpeg_turbo libpng mpfr openssl pango poppler readline sqlite;
   }; });
+} //
+lib.optionalAttrs (super ? "br-parser-tools-lib" && super ? "compiler-lib") {
+  br-parser-tools-lib = super.br-parser-tools-lib.overrideRacketDerivation (oldAttrs: { doInstallCheck = true; });
 }

--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -29,6 +29,9 @@
 , racket-lib ? racket // { env = racket.out; }
 , unzip ? pkgs.unzip
 , bash ? pkgs.bash
+, findutils ? pkgs.findutils
+, gnused ? pkgs.gnused
+, time ? pkgs.time
 , racketIndexPatch ? builtins.toFile "racket-index.patch" ''
     diff --git a/pkgs/racket-index/setup/scribble.rkt b/pkgs/racket-index/setup/scribble.rkt
     index c79af9bf85..e4a1cf93e3 100644
@@ -95,10 +98,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   reverseCircularBuildInputs = attrs.reverseCircularBuildInputs or [];
   src = attrs.src or null;
   srcs = [ src ] ++ attrs.extraSrcs or (map (input: input.src) reverseCircularBuildInputs);
+  doInstallCheck = attrs.doInstallCheck or false;
   inherit racket;
-  outputs = [ "out" "env" ];
+  outputs = [ "out" "env" ] ++ lib.optionals doInstallCheck [ "test" "testEnv" ];
 
-  phases = "unpackPhase patchPhase installPhase fixupPhase";
+  phases = "unpackPhase patchPhase installPhase fixupPhase installCheckPhase";
   unpackPhase = ''
     stripSuffix() {
       stripped=$1
@@ -275,6 +279,27 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     done
     find $env/share/racket/collects $env/share/racket/pkgs $env/lib/racket $env/bin -type d -empty -delete
     rm $env/share/racket/include
+  '';
+
+  installCheckPhase = if !doInstallCheck then null else let
+    testConfigBuildInputs = [ self.compiler-lib ] ++ self.compiler-lib.racketConfigBuildInputs ++
+      (builtins.filter (input: !builtins.elem input reverseCircularBuildInputs) racketBuildInputs);
+    testConfigBuildInputsStr = lib.concatStringsSep " " (map (drv: drv.env) testConfigBuildInputs);
+  in ''
+    runHook preInstallCheck
+    mkdir -p $testEnv/etc/racket $testEnv/share
+    racket ${make-config-rktd} $testEnv ${racket} $env ${testConfigBuildInputsStr} > $testEnv/etc/racket/config.rktd
+    ln -s ${self.compiler-lib.env}/share/racket $testEnv/share/racket
+    ${findutils}/bin/xargs -I {} -0 -n 1 -P ''${NIX_BUILD_CORES:-1} bash -c '
+      set -eu
+      testpath=''${1#*/share/racket/pkgs/}
+      logdir="$test/log/''${testpath%/*}"
+      mkdir -p "$logdir"
+      timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" |&
+        grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" |
+        tee "$logdir/''${1##*/}"
+    ' {} {} < <(${findutils}/bin/find "$env"/share/racket/pkgs/"$pname" -name '*.rkt' -print0)
+    runHook postInstallCheck
   '';
 } // attrs)) suppliedAttrs; in racketDerivation.overrideAttrs (oldAttrs: {
   passthru = oldAttrs.passthru or {} // {

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -8,6 +8,9 @@
 , racket-lib ? racket // { env = racket.out; }
 , unzip ? pkgs.unzip
 , bash ? pkgs.bash
+, findutils ? pkgs.findutils
+, gnused ? pkgs.gnused
+, time ? pkgs.time
 , racketIndexPatch ? builtins.toFile "racket-index.patch" ''
     diff --git a/pkgs/racket-index/setup/scribble.rkt b/pkgs/racket-index/setup/scribble.rkt
     index c79af9bf85..e4a1cf93e3 100644
@@ -74,10 +77,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   reverseCircularBuildInputs = attrs.reverseCircularBuildInputs or [];
   src = attrs.src or null;
   srcs = [ src ] ++ attrs.extraSrcs or (map (input: input.src) reverseCircularBuildInputs);
+  doInstallCheck = attrs.doInstallCheck or false;
   inherit racket;
-  outputs = [ "out" "env" ];
+  outputs = [ "out" "env" ] ++ lib.optionals doInstallCheck [ "test" "testEnv" ];
 
-  phases = "unpackPhase patchPhase installPhase fixupPhase";
+  phases = "unpackPhase patchPhase installPhase fixupPhase installCheckPhase";
   unpackPhase = ''
     stripSuffix() {
       stripped=$1
@@ -254,6 +258,27 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     done
     find $env/share/racket/collects $env/share/racket/pkgs $env/lib/racket $env/bin -type d -empty -delete
     rm $env/share/racket/include
+  '';
+
+  installCheckPhase = if !doInstallCheck then null else let
+    testConfigBuildInputs = [ self.compiler-lib ] ++ self.compiler-lib.racketConfigBuildInputs ++
+      (builtins.filter (input: !builtins.elem input reverseCircularBuildInputs) racketBuildInputs);
+    testConfigBuildInputsStr = lib.concatStringsSep " " (map (drv: drv.env) testConfigBuildInputs);
+  in ''
+    runHook preInstallCheck
+    mkdir -p $testEnv/etc/racket $testEnv/share
+    racket ${make-config-rktd} $testEnv ${racket} $env ${testConfigBuildInputsStr} > $testEnv/etc/racket/config.rktd
+    ln -s ${self.compiler-lib.env}/share/racket $testEnv/share/racket
+    ${findutils}/bin/xargs -I {} -0 -n 1 -P ''${NIX_BUILD_CORES:-1} bash -c '
+      set -eu
+      testpath=''${1#*/share/racket/pkgs/}
+      logdir="$test/log/''${testpath%/*}"
+      mkdir -p "$logdir"
+      timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" |&
+        grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" |
+        tee "$logdir/''${1##*/}"
+    ' {} {} < <(${findutils}/bin/find "$env"/share/racket/pkgs/"$pname" -name '*.rkt' -print0)
+    runHook postInstallCheck
   '';
 } // attrs)) suppliedAttrs; in racketDerivation.overrideAttrs (oldAttrs: {
   passthru = oldAttrs.passthru or {} // {


### PR DESCRIPTION
Solution: Run raco test on all rkt files when doInstallCheck enabled.

Adapted from the fractalide-tests target in Fractalide, but:
 - Instead of creating a separate derivation it just creates an output.
 - The test output is less spammy.
 - Don't rely on parallel, xargs has parallelization too.
 - Don't just show output in build output, it may interleave. Output
   to per-file output files too.

Fractalide still can't make use of the complete generic mechanism,
because we have directories we want to skip. But the required work in
Fractalide gets reduced to enabling doInstallCheck and overriding
installCheckPhase, and that's an improvement too.