### PR TITLE
Problem: pict-lib doesn't build with racket-full

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -45,8 +45,6 @@ in
     x86_64-darwin = genJobs (pkgs { system = "x86_64-darwin"; }) // {
       latest-nixpkgs = genJobs (pkgs { pkgs = import <nixpkgs>; system = "x86_64-darwin"; });
     };
-  } // lib.optionalAttrs (pkgs {}).racket-full.meta.available {
-    racket-full = genJobs (pkgs { overlays = [ (self: super: { racket = self.racket-full; }) ]; });
   } // lib.optionalAttrs isTravis {
     stage0-nix-prerequisites = (pkgs {}).racket2nix-stage0.buildInputs;
     travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix" "tests.light-tests"


### PR DESCRIPTION
It tries to run the tests, but the package is not there because it is
in the racket derivation.

There isn't much point in supporting racket-full, it was always just
'also there'. Actually, I thought I had already removed it. On
x86_64-darwin we don't even have one.

Solution: Remove racket-full jobs from release.nix.