### PR TITLE
Problem: installCheck: Does not fail when tests fail

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -294,9 +294,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
       testpath=''${1#*/share/racket/pkgs/}
       logdir="$test/log/''${testpath%/*}"
       mkdir -p "$logdir"
-      timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" |&
-        grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" |
-        tee "$logdir/''${1##*/}"
+      timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" \
+        &> >(grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" | tee "$logdir/''${1##*/}")
     ' {} {} < <(runHook installCheckFileFinder)
     runHook postInstallCheck
   '';

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -273,9 +273,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
       testpath=''${1#*/share/racket/pkgs/}
       logdir="$test/log/''${testpath%/*}"
       mkdir -p "$logdir"
-      timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" |&
-        grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" |
-        tee "$logdir/''${1##*/}"
+      timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" \
+        &> >(grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" | tee "$logdir/''${1##*/}")
     ' {} {} < <(runHook installCheckFileFinder)
     runHook postInstallCheck
   '';


### PR DESCRIPTION
To quote the bash manual:

    The return status of a pipeline is the exit status of the last command [ . . . ]

Solution: Do not filter test output in a pipeline, use process substitution.