### PR TITLE
Problem: Too much going on during eval

### DIFF
--- a/build-racket-default-overlay.nix
+++ b/build-racket-default-overlay.nix
@@ -3,6 +3,9 @@ let
   inherit (super.pkgs) lib;
 in
 
+lib.optionalAttrs (super ? "nix") {
+  racket2nix = super.nix.overrideRacketDerivation (oldAttrs: { pname = "racket2nix"; });
+} //
 lib.optionalAttrs (super ? "deinprogramm-signature" && super ? "icons") {
   deinprogramm-signature = super.deinprogramm-signature.overrideRacketDerivation (oldAttrs: { racketBuildInputs = oldAttrs.racketBuildInputs ++ [ self.icons ]; });
 } //

--- a/build-racket-racket2nix-overlay.nix
+++ b/build-racket-racket2nix-overlay.nix
@@ -1,0 +1,8 @@
+self: super: {
+  "nix" = self.lib.mkRacketDerivation rec {
+  pname = "nix";
+  src = ./nix;
+  racketThinBuildInputs = [ self."base" self."rackunit-lib" ];
+  };
+
+}

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -1,7 +1,7 @@
 { pkgs ? import ./pkgs {}
 , cacert ? pkgs.cacert
 , catalog ? ./catalog.rktd
-, racket-package-overlays ? [ (import ./build-racket-default-overlay.nix) ]
+, racket-package-overlays ? [ (import ./build-racket-racket2nix-overlay.nix) (import ./build-racket-default-overlay.nix) ]
 , racket-packages ? pkgs.callPackage ./racket-packages.nix {}
 }:
 

--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,14 @@
 { system ? builtins.currentSystem
 , overlays ? []
 , pkgs ? import ./pkgs { inherit overlays system; }
+, buildRacketPackage ? pkgs.buildRacketPackage
+, buildThinRacket ? pkgs.buildThinRacket
+, lib ? pkgs.lib
 , package ? null
 , pname ? null
 }:
 
-let
-  inherit (pkgs) buildRacketPackage buildThinRacket lib racket2nix-stage1;
-  attrs = pkgs // {
-    racket2nix = racket2nix-stage1;
-  };
-in
-if package == null then (attrs.racket2nix // attrs)
+if package == null then (pkgs.racket2nix // pkgs)
 else if builtins.isString package then buildRacketPackage package
 else buildThinRacket ({ inherit package; } //
   lib.optionalAttrs (builtins.isString pname) { inherit pname; })

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,7 +12,7 @@ pkgsFn = args: args.pkgs ((removeAttrs args [ "pkgs" ]) // { overlays = [ (self:
 
   racket2nix-stage0 = self.callPackage ../stage0.nix {};
   racket2nix-stage1 = self.callPackage ../stage1.nix {};
-  racket2nix = self.racket2nix-stage0;
+  racket2nix = self.buildRacketPackage "racket2nix";
   inherit (self.callPackage ../build-racket.nix {})
     buildRacket buildRacketPackage buildRacketCatalog
     buildThinRacket buildThinRacketPackage;

--- a/release.nix
+++ b/release.nix
@@ -18,7 +18,7 @@ let
       };
     };
     pkgs-all = pkgs.callPackage <racket2nix/catalog.nix> {};
-    racket2nix = pkgs.callPackage <racket2nix> {};
+    racket2nix = pkgs.racket2nix-stage1;
     tests = {
       inherit (pkgs.callPackage <racket2nix/test.nix> {}) light-tests;
     } // lib.optionalAttrs ((builtins.match ".*racket-minimal.*" pkgs.racket.name) != null) {
@@ -41,6 +41,21 @@ in
         diff -u racket-packages.nix $src/racket-packages.nix
       fi
     '';
+    racket2nix-overlay-updated = (pkgs {}).runCommand "racket2nix-overlay-updated" {
+      src = <racket2nix>;
+      buildInputs = builtins.attrValues { inherit (pkgs {}) bash cacert coreutils diffutils gnused nix racket-minimal; };
+    } ''
+      set -euo pipefail
+      cp -a $src src
+      chmod -R a+w src
+      cd src
+      bash ./update-racket2nix-overlay.sh
+      if ! diff -Nur ./ $src | tee $out; then
+        echo
+        echo ERROR: Your tree is out of date. Please run ./update-racket2nix-overlay.sh before commit.
+        exit 1
+      fi
+    '';
     latest-nixpkgs = genJobs (pkgs { pkgs = import <nixpkgs>; });
     x86_64-darwin = genJobs (pkgs { system = "x86_64-darwin"; }) // {
       latest-nixpkgs = genJobs (pkgs { pkgs = import <nixpkgs>; system = "x86_64-darwin"; });
@@ -48,6 +63,6 @@ in
   } // lib.optionalAttrs isTravis {
     stage0-nix-prerequisites = (pkgs {}).racket2nix-stage0.buildInputs;
     travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix" "tests.light-tests"
-                    "racket-packages-updated"
+                    "racket-packages-updated" "racket2nix-overlay-updated"
                     "racket-full.racket2nix" "api.override-racket-derivation" ];
   }

--- a/stage1.nix
+++ b/stage1.nix
@@ -7,11 +7,11 @@ inherit (pkgs) buildRacket nix nix-prefetch-git racket2nix-stage0 runCommand;
 
 # Don't just build a flat package, build it with flat racket2nix.
 buildRacketFlat = { ... }@args: (pkgs.overridePkgs (oldAttrs: {
-  overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix.flat; }) ];
+  overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix-stage0.flat; }) ];
 })).buildRacket (args // { flat = true; });
 
 buildThin = { ... }@args: (pkgs.overridePkgs (oldAttrs: {
-  overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix.thin; }) ];
+  overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix-stage0.thin; }) ];
 })).buildThinRacket args;
 
 attrOverrides = oldAttrs: {

--- a/update-racket2nix-overlay.sh
+++ b/update-racket2nix-overlay.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env nix-shell
+#! nix-shell --pure -p bash cacert gnused nix racket-minimal -i bash
+
+set -euo pipefail
+
+SCRIPT_NAME=${BASH_SOURCE[0]##*/}
+cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}"
+
+OUTPUT_FILE=build-racket-racket2nix-overlay.nix
+
+./racket2nix --thin ./nix | 
+  sed -e 's,src =.*,src = ./nix;,p' -e '/src =/,/}/d' \
+  > $OUTPUT_FILE.new
+mv $OUTPUT_FILE{.new,}


### PR DESCRIPTION
Because of how default.nix is set up, any use of buildRacket at all
involves bootstrapping and verifying racket2nix before you can get a
derivation or even a function.

The worst consequence of this right now is, when a build worker is
down, release.nix doesn't evaluate on hydra.

Solution: Make racket2nix from a static nix expression.

We check that the expression is up to date in release, just like with
racket-packages, and we do the full bootstrap and verification of
racket2nix in release only.