### PR TITLE
Problem: update-racket-packages not safe to run in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ compiled
 /pkgs-all
 result*
 /catalog.rktd.new
+/racket-packages.nix.??????

--- a/update-racket-packages.sh
+++ b/update-racket-packages.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell --pure -p bash cacert nix racket-minimal -i bash
+#! nix-shell --pure -p bash cacert coreutils nix racket-minimal -i bash
 
 set -e
 set -u
@@ -7,5 +7,6 @@ set -u
 SCRIPT_NAME=${BASH_SOURCE[0]##*/}
 cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}"
 
-./racket2nix --catalog catalog.rktd > racket-packages.nix.new
-mv racket-packages.nix{.new,}
+out=$(mktemp racket-packages.nix.XXXXXX)
+./racket2nix --catalog catalog.rktd > $out
+mv $out racket-packages.nix


### PR DESCRIPTION
This may sound like an exotic use case, but when iteratively fixing
things, running multiple update-racket-packages in parallel actually
makes sense.

You try to build something, it fails in multiple dependencies. You fix
one thing, start updating racket-packages to then run a test build of
that thing. While that is running, you fix the next thing, and want to
run tests for that. Currently you need to wait for the first update to
finish before starting the next, or they trip over each other's .new
files.

Solution: Use unique temporary files.

Now, when one update finishes, it can start running its build. If
while it's updating you make more changes, you can start an update
based on those, and then build based on those changes as soon
as the second update is done. The latest finished update wins.

Of course it is possible to confuse yourself about which changes are
in effect, but that's up to you. Generally this doesn't come up,
because there's a general direction of "forward", and if you get
some further updates than expected, it's not an issue.

    # make some changes then ...
    $ ./update-racket-packages.sh && nix-build --argstr package thing
    # while that is running, make more changes then run in parallel ...
    $ ./update-racket-packages.sh && nix-build --argstr package otherthing