### PR TITLE
Problem: overrides: Not combined w/ install-check-overrides

### DIFF
--- a/build-racket-default-overlay.nix
+++ b/build-racket-default-overlay.nix
@@ -23,10 +23,4 @@ lib.optionalAttrs (super ? "compatibility+compatibility-doc+data-doc+db-doc+dist
   buildInputs = oldAttrs.buildInputs or [] ++ builtins.attrValues {
     inherit (self.pkgs) glib cairo fontconfig gmp gtk3 gsettings-desktop-schemas libedit libjpeg_turbo libpng mpfr openssl pango poppler readline sqlite;
   }; });
-} //
-lib.optionalAttrs (super ? "compiler-lib") (let
-  mergeAttrs = builtins.foldl' (acc: attrs: acc // attrs) {};
-  wordsToList = words: builtins.filter (s: (builtins.isString s) && s != "") (builtins.split "[ \n]+" words);
-in mergeAttrs (map (package: lib.optionalAttrs (super ? "${package}") {
-  "${package}" = super."${package}".overrideRacketDerivation (oldAttrs: { doInstallCheck = true; });
-}) (wordsToList (builtins.readFile ./build-racket-install-check-overrides.txt))))
+}

--- a/build-racket-install-check-overlay.nix
+++ b/build-racket-install-check-overlay.nix
@@ -1,0 +1,11 @@
+self: super:
+let
+  inherit (super.pkgs) lib;
+in
+
+lib.optionalAttrs (super ? "compiler-lib") (let
+  mergeAttrs = builtins.foldl' (acc: attrs: acc // attrs) {};
+  wordsToList = words: builtins.filter (s: (builtins.isString s) && s != "") (builtins.split "[ \n]+" words);
+in mergeAttrs (map (package: lib.optionalAttrs (super ? "${package}") {
+  "${package}" = super."${package}".overrideRacketDerivation (oldAttrs: { doInstallCheck = true; });
+}) (wordsToList (builtins.readFile ./build-racket-install-check-overrides.txt))))

--- a/build-racket.nix
+++ b/build-racket.nix
@@ -1,7 +1,7 @@
 { pkgs ? import ./pkgs {}
 , cacert ? pkgs.cacert
 , catalog ? ./catalog.rktd
-, racket-package-overlays ? [ (import ./build-racket-racket2nix-overlay.nix) (import ./build-racket-default-overlay.nix) ]
+, racket-package-overlays ? [ (import ./build-racket-racket2nix-overlay.nix) (import ./build-racket-install-check-overlay.nix) (import ./build-racket-default-overlay.nix) ]
 , racket-packages ? pkgs.callPackage ./racket-packages.nix {}
 }:
 


### PR DESCRIPTION
The install-check-overrides simply overwrite any attributes earlier in
the overlay.

Solution: Make install-check-overrides their own overlay.

Order matters: racket2nix needs to come first, so that we can
eventually put it in install-check-overrides. default-overrides needs
to come after install-check-overrides so that the
overrideRacketDerivation in install-check-overrides doesn't discard
any overrideAttrs in default-overrides.