### PR TITLE
Problem: catalog-exclusions needs manual attention

### DIFF
--- a/catalog-exclusions.rktd
+++ b/catalog-exclusions.rktd
@@ -1,17 +1,1 @@
-("battle-arena"
- "brick-snip"
- "brick-tool"
- "character-creator"
- "dracula"
- "game-engine"
- "game-engine-demos-common"
- "game-engine-rpg"
- "game-engine-style-demos"
- "racket-bricks"
- "spaceship-game-demo"
- "survival"
- "ts-camp-jam-1"
- "ts-game-jam-1"
- "ts-curric-puzzles"
- "video-unstable")
-
+()

--- a/update-catalog.sh
+++ b/update-catalog.sh
@@ -12,5 +12,5 @@ echo NOTE: to download some pretty large git repos. Make sure you have
 echo NOTE: hundreds of megabytes of space.
 
 catalog=$(nix-build --no-out-link catalog.nix)
-./racket2nix --catalog $catalog --cache-catalog catalog.rktd --export-catalog > catalog.rktd.new
+./racket2nix --catalog $catalog --cache-catalog catalog.rktd --sanitize-catalog --export-catalog > catalog.rktd.new
 mv catalog.rktd.new catalog.rktd


### PR DESCRIPTION
The most annoying part of running bump-all is that any new packages
with broken dependencies must be added to catalog-exclusions, and any
packages that have been fixed need to be removed. We can detect this
automatically.

Solution: update-catalog: Remove packages with missing transdeps.