### PR TITLE
Problem: racket2nix-overlay-updated: Cannot succeed on NixOS

### DIFF
--- a/update-racket2nix-overlay.sh
+++ b/update-racket2nix-overlay.sh
@@ -8,7 +8,7 @@ cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}"
 
 OUTPUT_FILE=build-racket-racket2nix-overlay.nix
 
-./racket2nix --thin ./nix | 
+bash ./racket2nix --thin ./nix | 
   sed -e 's,src =.*,src = ./nix;,p' -e '/src =/,/}/d' \
   > $OUTPUT_FILE.new
 mv $OUTPUT_FILE{.new,}


### PR DESCRIPTION
In the sandbox there is no /usr/bin/env, so running ./racket2nix
inside a derivation fails.

Solution: update-racket2nix-overlay: Call ./racket2nix with explicit bash.

./release.sh now passes on NixOS.