### PR TITLE
Problem: admiral-edu-server: Test cannot succeed in sandbox

### DIFF
--- a/build-racket-install-check-overrides.txt
+++ b/build-racket-install-check-overrides.txt
@@ -1,6 +1,5 @@
 acl2s-scribblings
 adjutor
-admiral-edu-server
 algebraic
 anaphoric
 ansi-color


### PR DESCRIPTION
It assumes that zip is at /usr/bin/zip.

Solution: Remove from install-check-overrides.