### PR TITLE
Problem: failing installCheck tests

### DIFF
--- a/build-racket-install-check-overrides.txt
+++ b/build-racket-install-check-overrides.txt
@@ -1,6 +1,5 @@
 acl2s-scribblings
 adjutor
-admiral-edu-server
 algebraic
 anaphoric
 ansi-color
@@ -24,11 +23,9 @@ choose-out
 colon-kw
 colon-match
 command-tree
-compatibility-test
 component-test
 compose-app
 continued-fractions
-contract-profile
 control
 crc32c
 cs2500f16-jsonlab


### PR DESCRIPTION
 - admiral-edu-server: Assumes that zip is at /usr/bin/zip.
 - compatibility-test, contract-profile: Just fail without reporting
   any failed tests.

Solution: Remove from install-check-overrides.

Now we have a green baseline for future changes.