### PR TITLE
Problem: Unproductive caching and remoting

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -20,19 +20,27 @@ let
         path = runCommand pname {
           inherit package; outputHashMode = "recursive"; outputHashAlgo = "sha256";
           outputHash = builtins.readFile sha256;
+          preferLocalBuild = true;
+          allowSubstitutes = false;
         } ''
           cp -a $package $out
         '';
       in runCommand "${pname}.nix" {
         buildInputs = [ cacert racket2nix nix ];
         inherit path;
+        preferLocalBuild = true;
+        allowSubstitutes = false;
       } ''
         racket2nix --thin $path > $out
       '';
     buildThinRacket = { package, racket-packages ? default.racket-packages
                       , overlays ? default.racket-package-overlays
                       , attrOverrides ? (oldAttrs: {})
-                      , pname ? builtins.readFile (runCommand "pname" { inherit package; } ''
+                      , pname ? builtins.readFile (runCommand "pname" {
+                          inherit package;
+                          preferLocalBuild = true;
+                          allowSubstitutes = false;
+                        } ''
                           printf '%s' $(basename $(stripHash "$package")) > $out
                         '')
                       }: let
@@ -56,6 +64,8 @@ let
       inherit package;
       buildInputs = [ cacert racket2nix nix ];
       flatArg = lib.optionalString flat "--flat";
+      preferLocalBuild = true;
+      allowSubstitutes = false;
     } ''
       racket2nix $flatArg --catalog ${catalog} $package > $out
     '';

--- a/integration-tests/default.nix
+++ b/integration-tests/default.nix
@@ -36,6 +36,8 @@ z = [ "a" ];
 inherit (builtins) concatStringsSep;
 
 nameDepsToDrv = name: deps: pkgs.runCommand name {
+  preferLocalBuild = true;
+  allowSubstitutes = false;
 } ''
   mkdir $out
   cat > $out/info.rkt <<EOF

--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -76,6 +76,8 @@ lib.fixedRacketSource = { pathname, sha256 }: pkgs.runCommand (baseNameOf (self.
   outputHashAlgo = "sha256";
   outputHash = sha256;
   buildInputs = [ pkgs.coreutils ];
+  preferLocalBuild = true;
+  allowSubstitutes = false;
 } ''
   cp -a $pathname $out && exit
   echo ERROR: Unable to find source for $name: $pathname

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -55,6 +55,8 @@ lib.fixedRacketSource = { pathname, sha256 }: pkgs.runCommand (baseNameOf (self.
   outputHashAlgo = "sha256";
   outputHash = sha256;
   buildInputs = [ pkgs.coreutils ];
+  preferLocalBuild = true;
+  allowSubstitutes = false;
 } ''
   cp -a $pathname $out && exit
   echo ERROR: Unable to find source for $name: $pathname

--- a/release.nix
+++ b/release.nix
@@ -44,6 +44,8 @@ in
     racket2nix-overlay-updated = (pkgs {}).runCommand "racket2nix-overlay-updated" {
       src = <racket2nix>;
       buildInputs = builtins.attrValues { inherit (pkgs {}) bash cacert coreutils diffutils gnused nix racket-minimal; };
+      preferLocalBuild = true;
+      allowSubstitutes = false;
     } ''
       set -euo pipefail
       cp -a $src src


### PR DESCRIPTION
Simple tasks like copying a file from one place to another, or
processing some small text file, should not incur the overhead and
latency of talking to upstream caches or build workers. Just do it.

Solution: Set preferLocalBuild and allowSubstitutes where appropriate.

Applies to most runCommands, but not the ones in catalog.nix, which
are reasonably time-consuming.