### PR TITLE
Problem: Reinvented wheel, not being DRY, unfriendly attrs

### DIFF
--- a/build-racket.nix
+++ b/build-racket.nix
@@ -1,12 +1,12 @@
 { pkgs ? import ./pkgs {}
-, cacert ? pkgs.cacert
+, callPackage ? pkgs.callPackage
+, callPackageFull ? pkgs.callPackageFull
 , catalog ? ./catalog.rktd
 , racket-package-overlays ? [ (import ./build-racket-racket2nix-overlay.nix) (import ./build-racket-install-check-overlay.nix) (import ./build-racket-default-overlay.nix) ]
-, racket-packages ? pkgs.callPackage ./racket-packages.nix {}
+, racket-packages ? callPackageFull ./racket-packages.nix {}
 }:
 
-let
-  inherit (pkgs) buildEnv lib nix racket2nix runCommand;
+callPackage ({buildEnv, cacert, lib, nix, racket2nix, runCommand}: let
   default = { inherit catalog racket-package-overlays racket-packages; };
   apply-overlays = rpkgs: overlays: if overlays == [] then rpkgs else
     apply-overlays (rpkgs.extend (builtins.head overlays)) (builtins.tail overlays);
@@ -77,8 +77,8 @@ let
         nix = if !buildNix then null else
           buildRacketNix { inherit catalog flat package; } // lib.optionalAttrs (builtins.isString pname) { inherit pname; };
         self = let
-          pname = if buildNix then ((pkgs.callPackage nix {}).overrideAttrs attrOverrides).pname else package;
-          rpkgs = if buildNix then (pkgs.callPackage nix {}).racket-packages else default.racket-packages;
+          pname = if buildNix then ((callPackageFull nix {}).overrideAttrs attrOverrides).pname else package;
+          rpkgs = if buildNix then (callPackageFull nix {}).racket-packages else default.racket-packages;
           racket-packages = apply-overlays rpkgs overlays;
         in
           (racket-packages."${pname}".overrideAttrs (oldAttrs: {
@@ -116,4 +116,4 @@ let
     '';
   };
 in
-attrs
+attrs) {}

--- a/catalog.nix
+++ b/catalog.nix
@@ -1,11 +1,10 @@
-{ pkgs ? import ./pkgs { }
-, cacert ? pkgs.cacert
+{ pkgs ? import ./pkgs {}
+, callPackage ? pkgs.callPackage
 , exclusions ? ./catalog-exclusions.rktd
 , overrides ? ./catalog-overrides.rktd
 }:
 
-let
-inherit (pkgs) cacert racket runCommand fetchurl;
+callPackage ({cacert, fetchurl, racket, runCommand}: let
 attrs = rec {
   releaseCatalog = with (builtins.fromJSON (builtins.readFile ./release-catalog.json));
   runCommand "release-catalog" {
@@ -54,4 +53,4 @@ attrs = rec {
   '';
 };
 in
-attrs.merged-catalog // attrs // { inherit attrs; }
+attrs.merged-catalog // attrs // { inherit attrs; }) {}

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,12 @@
 { system ? builtins.currentSystem
-, overlays ? []
-, pkgs ? import ./pkgs { inherit overlays system; }
-, buildRacketPackage ? pkgs.buildRacketPackage
-, buildThinRacket ? pkgs.buildThinRacket
-, lib ? pkgs.lib
+, pkgs ? import ./pkgs { inherit system; }
+, callPackage ? pkgs.callPackage
 , package ? null
 , pname ? null
 }:
 
-if package == null then (pkgs.racket2nix // pkgs)
+callPackage ({buildRacketPackage, buildThinRacket, lib, racket2nix}:
+if package == null then (racket2nix // pkgs)
 else if builtins.isString package then buildRacketPackage package
 else buildThinRacket ({ inherit package; } //
-  lib.optionalAttrs (builtins.isString pname) { inherit pname; })
+  lib.optionalAttrs (builtins.isString pname) { inherit pname; })) {}

--- a/integration-tests/default.nix
+++ b/integration-tests/default.nix
@@ -1,8 +1,9 @@
 { pkgs ? import ../pkgs {}
+, callPackage ? pkgs.callPackage
 }:
 
-let
-inherit (pkgs) buildRacket buildRacketCatalog racket racket2nix;
+callPackage ({buildRacket, buildRacketCatalog, callPackageFull, lib, racket, racket2nix,
+              runCommand}: let
 
 deps = {
 a = [ "b" "c" "f" "g" "n" "o" "s" "y" ];
@@ -35,7 +36,7 @@ z = [ "a" ];
 
 inherit (builtins) concatStringsSep;
 
-nameDepsToDrv = name: deps: pkgs.runCommand name {
+nameDepsToDrv = name: deps: runCommand name {
   preferLocalBuild = true;
   allowSubstitutes = false;
 } ''
@@ -75,9 +76,7 @@ EOF
 EOF
 '';
 
-inherit (pkgs.lib) mapAttrs;
-
-packages = mapAttrs nameDepsToDrv deps;
+packages = lib.mapAttrs nameDepsToDrv deps;
 
 attrs = rec {
   catalog = buildRacketCatalog [ (builtins.attrValues packages) ];
@@ -86,4 +85,4 @@ attrs = rec {
   circular-subdeps-flat = map (p: p.override { flat = true; }) circular-subdeps;
 }; in
 
-attrs // { inherit attrs; }
+attrs // { inherit attrs; }) {}

--- a/stage0.nix
+++ b/stage0.nix
@@ -1,10 +1,10 @@
 { pkgs ? import ./pkgs {}
-, cacert ? pkgs.cacert
+, callPackage ? pkgs.callPackage
 , catalog ? ./catalog.rktd
 }:
 
+callPackage ({cacert, callPackageFull, nix, racket, runCommand}:
 let
-inherit (pkgs) nix racket runCommand;
 nix-command = nix;
 bootstrap = name: extraArgs: let
   nix = runCommand "${name}.nix" {
@@ -14,7 +14,7 @@ bootstrap = name: extraArgs: let
   } ''
     racket -N racket2nix $src/racket2nix.rkt $extraArgs --catalog ${catalog} $src > $out
   '';
-  nixAttrs = pkgs.callPackage nix {};
+  nixAttrs = callPackageFull nix {};
   out = if nixAttrs ? overrideAttrs then nixAttrs.overrideAttrs (oldAttrs: {
     name = "${name}";
     postInstall = "$out/bin/racket2nix --test";
@@ -27,5 +27,5 @@ in
 (bootstrap "racket2nix-stage0" "") // {
   flat = bootstrap "racket2nix-stage0.flat" "--flat";
   thin = let inherit (bootstrap "racket2nix-stage0.thin" "--thin") nix; in
-    ((pkgs.callPackage ./racket-packages.nix {}).extend (import nix)).nix // { inherit nix; };
-}
+    ((callPackageFull ./racket-packages.nix {}).extend (import nix)).nix // { inherit nix; };
+}) {}

--- a/stage1.nix
+++ b/stage1.nix
@@ -1,18 +1,17 @@
 { pkgs ? import ./pkgs {}
-, cacert ? pkgs.cacert
+, callPackage ? pkgs.callPackage
 }:
 
-let
-inherit (pkgs) buildRacket nix nix-prefetch-git racket2nix-stage0 runCommand;
+callPackage ({buildRacket, cacert, nix, nix-prefetch-git, racket2nix-stage0, runCommand}: let
 
 # Don't just build a flat package, build it with flat racket2nix.
-buildRacketFlat = { ... }@args: (pkgs.overridePkgs (oldAttrs: {
-  overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix-stage0.flat; }) ];
-})).buildRacket (args // { flat = true; });
+buildRacketFlat = { ... }@args: (pkgs.extend
+  (self: super: { racket2nix = super.racket2nix-stage0.flat; })
+).buildRacket (args // { flat = true; });
 
-buildThin = { ... }@args: (pkgs.overridePkgs (oldAttrs: {
-  overlays = oldAttrs.overlays ++ [ (self: super: { racket2nix = super.racket2nix-stage0.thin; }) ];
-})).buildThinRacket args;
+buildThin = { ... }@args: (pkgs.extend
+  (self: super: { racket2nix = super.racket2nix-stage0.thin; })
+).buildThinRacket args;
 
 attrOverrides = oldAttrs: {
   buildInputs = oldAttrs.buildInputs ++ [ verify ];
@@ -35,4 +34,4 @@ verify = runCommand "verify-stage1.sh" {
 '';
 
 in
-stage1
+stage1) {}

--- a/test.nix
+++ b/test.nix
@@ -1,11 +1,11 @@
 { pkgs ? import ./pkgs {}
-, buildDrvs ? pkgs.buildDrvs
+, callPackage ? pkgs.callPackage
 , integration-tests ? pkgs.callPackage ./integration-tests {}
 }:
 
+callPackage ({buildDrvs, buildRacket, buildRacketPackage, racket2nix}:
 let it-attrs = integration-tests.attrs; in
 let
-  inherit (pkgs) buildRacket buildRacketPackage racket2nix;
   attrs = rec {
   racket-doc = buildRacketPackage "racket-doc";
   typed-map-lib = buildRacket { package = "typed-map-lib"; buildNix = true; };
@@ -23,4 +23,4 @@ let
   integration-tests = it-attrs;
 };
 in
-attrs.light-tests // attrs
+attrs.light-tests // attrs) {}


### PR DESCRIPTION
 - When you do:

   `nix-instantiate --eval -E 'builtins.attrNames (import ./pkgs {})'`

   ... you get all of nixpkgs in your face. This is not very friendly
   when troubleshooting or otherwise looking around in the system. And
   pkgs is what we export to users of the top-level expression too.
 - We have implemented our own overlay system.
 - We are repeating ourselves in headers: `, attr ? pkgs.attr`

These are remnants from early days and we know better now.

Solution: Use makeScope in pkgs, and mostly don't query pkgs directly.

Now we get a nice overview of what definitions we actually touched:

    $ nix-instantiate --eval -E 'builtins.attrNames (import ./pkgs {})'
    [ "buildDrvs" "buildRacket" "buildRacketCatalog" "buildRacketPackage"
      "buildThinRacket" "buildThinRacketPackage" "callPackage" "newScope"
      "nixpkgs" "overrideScope" "overrideScope'" "packages" "pkgs"
      "racket" "racket-full" "racket-minimal" "racket2nix" "racket2nix-stage0"
      "racket2nix-stage1" ]

Be consistent and use callPackage to query attributes from pkgs,
whether they are explicit or inherited from nixpkgs. Exceptions are
bootstrapping `callPackage` itself, and attributes needed for other
file parameters with defaults.

Nix code supplied by users and the generated code from racket2nix can
reasonably expect to be able to address `pkgs` directly, so call them
with `callPackageFull`, which supplies a fully populated `pkgs`
inheriting from the normal pkgs.

Removing a bunch of header arguments removes accidental inconsistency
in what e.g. `racket` might mean when files call each other, but it
does make it a bit more awkward to override things, i.e.:

    nix-build --arg attr something release.nix

becomes

    nix-build -E '((import ./pkgs {}).extend (self: { attr = something; })).callPackage ./release.nix {}'

On the other hand at the current maturity level, I can't remember when
I last overrode something or even called a file directly -- I mostly go
via the conveniences in default.nix.