### PR TITLE
Problem: release: overlay-updated sensitive to symlinks

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -40,7 +40,7 @@ in
       fi
     '';
     racket2nix-overlay-updated = runCommand "racket2nix-overlay-updated" {
-      src = <racket2nix>;
+      src = builtins.filterSource (path: type: type != "symlink") <racket2nix>;
       buildInputs = builtins.attrValues { inherit bash cacert coreutils diffutils gnused nix racket; };
       preferLocalBuild = true;
       allowSubstitutes = false;


### PR DESCRIPTION
racket2nix-overlay-updated uses a crude approach to checking whether
the racket2nix-overlay is up-to-date. This is a good thing, because
it makes it insensitive to changes in exactly how the overlay is
expressed.

But it also makes it overly sensitive to irrelevant things like
symlinks in the directory. When diff sees a dangling symlink (like
a result symlink read in a sandbox) it treats it as an error.

Solution: Filter out symlinks.