### PR TITLE
Problem: update-catalog: Breaks when run inside git-rebase

### DIFF
--- a/update-catalog.sh
+++ b/update-catalog.sh
@@ -12,5 +12,6 @@ echo NOTE: to download some pretty large git repos. Make sure you have
 echo NOTE: hundreds of megabytes of space.
 
 catalog=$(nix-build --no-out-link catalog.nix)
+unset GIT_DIR GIT_WORK_TREE  # These interfere with nix-prefetch-git
 ./racket2nix --catalog $catalog --cache-catalog catalog.rktd --sanitize-catalog --export-catalog > catalog.rktd.new
 mv catalog.rktd.new catalog.rktd


### PR DESCRIPTION
When putting together a long line of commits, it is helpful to be able
to batch-regenerate the various generated files in the repo using
`git rebase --exec`. When running, git-rebase sets `GIT_DIR` and
`GIT_WORK_TREE`, which make nix-prefetch-git want to reinitialize the
racket2nix repo rather than creating a fresh one in the temp dir, and
it confuses itself and bails out.

Currently the workaround is to remember to call update-catalog with
`env -u GIT_DIR -u GIT_WORK_TREE ./update-catalog.sh` during git
rebase.

Solution: Unset the git variables before calling racket2nix.

The real solution is to fix nix-prefetch-git upstream, I will create
an issue or PR for this.