### PR TITLE
 Problem: Not looking up package sources by racket version

### DIFF
--- a/catalog.rktd
+++ b/catalog.rktd
@@ -16608,7 +16608,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "490ee40e32cbaa818798aacca89fe4e3b3fc772b")
              (checksum-error .
               #f)
              (conflicts .
@@ -16631,6 +16631,8 @@
               ((lib "distributed-places-test/test/racket/place/distributed/bank.rkt") (lib "distributed-places-test/test/racket/place/distributed/restarter.rkt") (lib "distributed-places-test/test/racket/place/distributed/distributed.rkt") (lib "distributed-places-test/test/racket/place/distributed/tuple.rkt")))
              (name .
               "distributed-places-test")
+             (nix-sha256 .
+              "009sflz25ps7mj07slv1gw3z9i6b3wzpyxaxn8ji0wbry02w0vvd")
              (ring .
               0)
              (search-terms .
@@ -16641,7 +16643,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/distributed-places/?path=distributed-places-test")
              (tags .
               ("main-tests"))
              (versions .
@@ -16696,7 +16698,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "2338b6dbb7c4b3c4ad35917a09eb173059387668")
              (checksum-error .
               #f)
              (conflicts .
@@ -16719,6 +16721,8 @@
               ())
              (name .
               "distro-build")
+             (nix-sha256 .
+              "1qpr6hc8z60y9ngg0v54cp4wri5z3ng4ns7yabnrdccacylwvk19")
              (ring .
               0)
              (search-terms .
@@ -16729,7 +16733,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/distro-build/?path=distro-build")
              (tags .
               ())
              (versions .
@@ -17589,7 +17593,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "8632512357c53d2d085a68545b2e093a9f9677be")
              (checksum-error .
               #f)
              (conflicts .
@@ -17622,7 +17626,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/8632512357c53d2d085a68545b2e093a9f9677be/draw-i386-macosx.zip")
              (tags .
               ())
              (versions .
@@ -17677,7 +17681,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "ecd61bfff1daa6e72ab14c73bfa480499717da29")
              (checksum-error .
               #f)
              (conflicts .
@@ -17710,7 +17714,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/ecd61bfff1daa6e72ab14c73bfa480499717da29/draw-i386-macosx-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -17803,7 +17807,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "552c18b393b3377b051da48aef8b8d6883615029")
              (checksum-error .
               #f)
              (conflicts .
@@ -17836,7 +17840,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/552c18b393b3377b051da48aef8b8d6883615029/draw-ppc-macosx.zip")
              (tags .
               ())
              (versions .
@@ -17891,7 +17895,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "a68c25d5794dff8f4f46eaccea942d2f04f32ca3")
              (checksum-error .
               #f)
              (conflicts .
@@ -17924,7 +17928,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/a68c25d5794dff8f4f46eaccea942d2f04f32ca3/draw-ppc-macosx-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -18036,7 +18040,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "915598defe21a2213c2833b45ace0c62fa31b39e")
              (checksum-error .
               #f)
              (conflicts .
@@ -18069,7 +18073,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/915598defe21a2213c2833b45ace0c62fa31b39e/draw-win32-i386.zip")
              (tags .
               ())
              (versions .
@@ -18124,7 +18128,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "3f5fb8b2e1ce9802a71328ee338e277573eb9cc9")
              (checksum-error .
               #f)
              (conflicts .
@@ -18157,7 +18161,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/3f5fb8b2e1ce9802a71328ee338e277573eb9cc9/draw-win32-i386-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -18231,7 +18235,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "d5769e02a39715de02b3c91c55a4d366dbbcb7fd")
              (checksum-error .
               #f)
              (conflicts .
@@ -18264,7 +18268,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/d5769e02a39715de02b3c91c55a4d366dbbcb7fd/draw-win32-x86_64.zip")
              (tags .
               ())
              (versions .
@@ -18319,7 +18323,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "c6c2edb3e086033e24a8121d85675f1bc11b7705")
              (checksum-error .
               #f)
              (conflicts .
@@ -18352,7 +18356,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/c6c2edb3e086033e24a8121d85675f1bc11b7705/draw-win32-x86_64-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -18445,7 +18449,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "bbbbcdc28aa69e11c7d7796d6796f34acf48b8e9")
              (checksum-error .
               #f)
              (conflicts .
@@ -18478,7 +18482,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/bbbbcdc28aa69e11c7d7796d6796f34acf48b8e9/draw-x86_64-linux-natipkg-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -18552,7 +18556,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "d47568a60e3e12793f2c49b322ad49c2a8ec8d26")
              (checksum-error .
               #f)
              (conflicts .
@@ -18585,7 +18589,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/d47568a60e3e12793f2c49b322ad49c2a8ec8d26/draw-x86_64-macosx.zip")
              (tags .
               ())
              (versions .
@@ -18640,7 +18644,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "552725bedd421a4c9979c639b5082ea0352f9ee6")
              (checksum-error .
               #f)
              (conflicts .
@@ -18673,7 +18677,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/552725bedd421a4c9979c639b5082ea0352f9ee6/draw-x86_64-macosx-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -27589,7 +27593,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "eb80f658a4b35757687eb26fa48a16d57685ef82")
              (checksum-error .
               #f)
              (conflicts .
@@ -27612,6 +27616,8 @@
               ((lib "pkg/gui/start.rkt")))
              (name .
               "gui-pkg-manager")
+             (nix-sha256 .
+              "1f59a35lw537h5gcg8mhif70mmhaa0kmfw4i6bwv4d15pz3zzrlf")
              (ring .
               0)
              (search-terms .
@@ -27624,7 +27630,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/gui-pkg-manager/?path=gui-pkg-manager")
              (tags .
               ())
              (versions .
@@ -27679,7 +27685,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "eb80f658a4b35757687eb26fa48a16d57685ef82")
              (checksum-error .
               #f)
              (conflicts .
@@ -27702,6 +27708,8 @@
               ((lib "pkg/gui/scribblings/gui-pkg-manager.scrbl")))
              (name .
               "gui-pkg-manager-doc")
+             (nix-sha256 .
+              "1f59a35lw537h5gcg8mhif70mmhaa0kmfw4i6bwv4d15pz3zzrlf")
              (ring .
               0)
              (search-terms .
@@ -27714,7 +27722,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/gui-pkg-manager/?path=gui-pkg-manager-doc")
              (tags .
               ())
              (versions .
@@ -27902,7 +27910,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f")
+              "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (checksum-error .
               #f)
              (conflicts .
@@ -27928,7 +27936,7 @@
              (name .
               "hackett")
              (nix-sha256 .
-              "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq")
+              "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib")
              (ring .
               1)
              (search-terms .
@@ -27943,7 +27951,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "https://github.com/lexi-lambda/hackett.git?path=hackett")
+              "https://github.com/lexi-lambda/hackett.git?path=hackett#f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (tags .
               ("lang" "language"))
              (versions .
@@ -28005,7 +28013,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f")
+              "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (checksum-error .
               #f)
              (conflicts .
@@ -28031,7 +28039,7 @@
              (name .
               "hackett-demo")
              (nix-sha256 .
-              "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq")
+              "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib")
              (ring .
               1)
              (search-terms .
@@ -28044,7 +28052,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "https://github.com/lexi-lambda/hackett.git?path=hackett-demo")
+              "https://github.com/lexi-lambda/hackett.git?path=hackett-demo#f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (tags .
               ())
              (versions .
@@ -28106,7 +28114,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f")
+              "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (checksum-error .
               #f)
              (conflicts .
@@ -28132,7 +28140,7 @@
              (name .
               "hackett-doc")
              (nix-sha256 .
-              "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq")
+              "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib")
              (ring .
               1)
              (search-terms .
@@ -28145,7 +28153,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "https://github.com/lexi-lambda/hackett.git?path=hackett-doc")
+              "https://github.com/lexi-lambda/hackett.git?path=hackett-doc#f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (tags .
               ())
              (versions .
@@ -28207,7 +28215,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f")
+              "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (checksum-error .
               #f)
              (conflicts .
@@ -28233,7 +28241,7 @@
              (name .
               "hackett-lib")
              (nix-sha256 .
-              "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq")
+              "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib")
              (ring .
               1)
              (search-terms .
@@ -28246,7 +28254,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "https://github.com/lexi-lambda/hackett.git?path=hackett-lib")
+              "https://github.com/lexi-lambda/hackett.git?path=hackett-lib#f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (tags .
               ())
              (versions .
@@ -28308,7 +28316,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f")
+              "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (checksum-error .
               #f)
              (conflicts .
@@ -28334,7 +28342,7 @@
              (name .
               "hackett-test")
              (nix-sha256 .
-              "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq")
+              "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib")
              (ring .
               1)
              (search-terms .
@@ -28347,7 +28355,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "https://github.com/lexi-lambda/hackett.git?path=hackett-test")
+              "https://github.com/lexi-lambda/hackett.git?path=hackett-test#f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea")
              (tags .
               ())
              (versions .
@@ -28478,7 +28486,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "3c31daccf0f61bb06aa65e36d72acc0ef2f453da")
+              "233b17e820bdd9b859f551bf4714204718d04306")
              (checksum-error .
               #f)
              (conflicts .
@@ -28502,7 +28510,7 @@
              (name .
               "handin")
              (nix-sha256 .
-              "09vqljgvz43gymc2q4i40mg551xxhb9pf4zkgnprdrvjhi6ihdss")
+              "1n46sj9wxq22gqbn1jd3q4pjhf3vmdxix5lji2h5zffa0rmakyda")
              (ring .
               0)
              (search-terms .
@@ -28513,7 +28521,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "github://github.com/plt/handin/for-v5.3.6")
+              "github://github.com/plt/handin/master")
              (tags .
               ())
              (versions .
@@ -29277,7 +29285,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "fd89d2af7df5aa3db770049663437484d7700820")
              (checksum-error .
               #f)
              (conflicts .
@@ -29300,6 +29308,8 @@
               ((lib "honu/tests/test-docs-complete.rkt") (lib "honu/private/lang/reader.rkt") (lib "honu-parse/syntax.rkt") (lib "honu/debug.rkt") (lib "honu-parse/wrap.rkt") (lib "honu-parse/operator.rkt") (lib "honu/syntax-parse.rkt") (lib "honu/core/private/macro.rkt") (lib "honu/core/runtime.rkt") (lib "honu/private/common.rkt") (lib "honu/core/api.rkt") (lib "honu/core/private/struct.rkt") (lib "honu/main.rkt") (lib "honu/tests/linq.rkt") (lib "honu-parse/debug.rkt") (lib "honu/syntax.rkt") (lib "honu-parse/literals.rkt") (lib "honu-parse/macro.rkt") (lib "honu/core/lang/reader.rkt") (lib "honu-parse/transformer.rkt") (lib "honu/lang/reader.rkt") (lib "honu-parse/arithmetic.rkt") (lib "honu-parse/define.rkt") (lib "honu/core/private/honu-top.rkt") (lib "honu/private/main.rkt") (lib "honu-parse/template.rkt") (lib "honu/core/read.rkt") (lib "honu/core/main.rkt") (lib "honu/core/private/util.rkt") (lib "honu/core/private/literals.rkt") (lib "honu-parse/unparsed-begin.rkt") (lib "honu/core/private/honu.rkt") (lib "honu-parse/main.rkt") (lib "honu-parse/old-literals.rkt") (lib "honu/tests/xml.rkt") (lib "honu/scribblings/honu.scrbl") (lib "honu-parse/compile.rkt") (lib "honu/core/private/class.rkt") (lib "honu-parse/parse.rkt") (lib "honu/core/private/operator.rkt") (lib "honu/core/language.rkt") (lib "honu/tests/macros.rkt") (lib "honu/tests/check.rkt")))
              (name .
               "honu")
+             (nix-sha256 .
+              "10ph1fj376drx8p9g4ak5cdjrhmjgwpd4w7h334b6fx4aja2bkss")
              (ring .
               0)
              (search-terms .
@@ -29312,7 +29322,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/honu")
              (tags .
               ())
              (versions .
@@ -50650,7 +50660,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "e11e7e4cd655b958296055f490ea8eadf5ea5ce7")
+              "582728d7a724674b58c6af8d2b20a6513947152a")
              (checksum-error .
               #f)
              (conflicts .
@@ -50674,7 +50684,7 @@
              (name .
               "plai-typed")
              (nix-sha256 .
-              "1sc9xjnqrkq1fv6ymlbln1cnbpw8sxzlwwi93scl8ngqq1wdvff2")
+              "03bqrf53ll6yzzh41slmdaqsffpi92wsshj8vy2i36mbkc7rzy15")
              (ring .
               1)
              (search-terms .
@@ -50687,7 +50697,7 @@
                     (textbook .
                      #t)))
              (source .
-              "github://github.com/mflatt/plai-typed/no-deps")
+              "github://github.com/mflatt/plai-typed/master")
              (tags .
               ("language" "textbook"))
              (versions .
@@ -50735,7 +50745,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "e010d9718916394b1b3545cb2f7a49c27904e873")
+              "ff05b257cc8739d2f4ad8f33b65440635ab9cce0")
              (checksum-error .
               #f)
              (conflicts .
@@ -50759,7 +50769,7 @@
              (name .
               "plai-typed-s-exp-match")
              (nix-sha256 .
-              "1rfa6zxngx1x011m7vlizrs6v6r6vn586icwzh0m0gj077dwslww")
+              "0k2knsg04s641aw4gn5ncwbvjp973px0jrm919vxy8gdizlvri22")
              (ring .
               1)
              (search-terms .
@@ -50770,7 +50780,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "github://github.com/mflatt/plai-typed-s-exp-match/no-deps")
+              "github://github.com/mflatt/plai-typed-s-exp-match/master")
              (tags .
               ())
              (versions .
@@ -51497,7 +51507,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "cb8fde7a9e5fad41e4f90ecca5f92921fdc00a52")
              (checksum-error .
               #f)
              (conflicts .
@@ -51520,6 +51530,8 @@
               ())
              (name .
               "plt-services")
+             (nix-sha256 .
+              "10kmcq77wjrf5maimbc6ac6c34xvmf45cb8l3k35alz2kag3i07x")
              (ring .
               0)
              (search-terms .
@@ -51532,7 +51544,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/racket/?path=pkgs/plt-services")
              (tags .
               ("deprecated"))
              (versions .
@@ -51587,7 +51599,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "5697a81d84117f9341686783b02299f74656918a")
              (checksum-error .
               #f)
              (conflicts .
@@ -51610,6 +51622,8 @@
               ())
              (name .
               "plt-web")
+             (nix-sha256 .
+              "0hzrp84cg3gl489y9nidzjqdya64wkqd48w2rlarv3w5ldw0nppl")
              (ring .
               0)
              (search-terms .
@@ -51620,7 +51634,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/plt-web/?path=plt-web")
              (tags .
               ())
              (versions .
@@ -51675,7 +51689,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "5697a81d84117f9341686783b02299f74656918a")
              (checksum-error .
               #f)
              (conflicts .
@@ -51698,6 +51712,8 @@
               ((lib "plt-web/plt-web.scrbl")))
              (name .
               "plt-web-doc")
+             (nix-sha256 .
+              "0hzrp84cg3gl489y9nidzjqdya64wkqd48w2rlarv3w5ldw0nppl")
              (ring .
               0)
              (search-terms .
@@ -51712,7 +51728,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/plt-web/?path=plt-web-doc")
              (tags .
               ())
              (versions .
@@ -53087,7 +53103,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "74dfaf1d6317a9f5479ae5492e874e9e73888a46")
+              "3703edda0c6b9f5ef7e7bf39b933cb1d0e9a82b5")
              (checksum-error .
               #f)
              (conflicts .
@@ -53111,7 +53127,7 @@
              (name .
               "portaudio")
              (nix-sha256 .
-              "1zczwx2z5kw85h15bw3xikwnjb4mxw4n4g8x7wkzqfrkvll8xmsb")
+              "1132wfqdapn7yswhkp7rbvc6lymqs1wgala8rnka92j6z5ms8rln")
              (ring .
               1)
              (search-terms .
@@ -53126,7 +53142,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "github://github.com/jbclements/portaudio/pre-6/")
+              "github://github.com/jbclements/portaudio/master/")
              (tags .
               ("audio" "ffi" "io"))
              (versions .
@@ -56650,7 +56666,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "2b0a4a12fc5fc8a304bcba60c09af2f8b75988c5")
              (checksum-error .
               #f)
              (conflicts .
@@ -56683,7 +56699,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/2b0a4a12fc5fc8a304bcba60c09af2f8b75988c5/racket-i386-macosx-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -57231,7 +57247,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "a36e58d540359092d684bd3a277d0068cff04afa")
              (checksum-error .
               #f)
              (conflicts .
@@ -57264,7 +57280,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/a36e58d540359092d684bd3a277d0068cff04afa/racket-ppc-macosx-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -58020,7 +58036,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "c57a6dae91081a4284d329364ad566c108d84747")
              (checksum-error .
               #f)
              (conflicts .
@@ -58053,7 +58069,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/c57a6dae91081a4284d329364ad566c108d84747/racket-win32-i386.zip")
              (tags .
               ())
              (versions .
@@ -58108,7 +58124,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "5eeac0afec99043631567829e4450694c1a913e2")
              (checksum-error .
               #f)
              (conflicts .
@@ -58141,7 +58157,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/5eeac0afec99043631567829e4450694c1a913e2/racket-win32-i386-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -58215,7 +58231,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "1026e430bb077a696084e702f5e8889f5b7dd55e")
              (checksum-error .
               #f)
              (conflicts .
@@ -58248,7 +58264,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/1026e430bb077a696084e702f5e8889f5b7dd55e/racket-win32-x86_64.zip")
              (tags .
               ())
              (versions .
@@ -58303,7 +58319,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "cf14b039901df7ede55fa128e206679f44d2f9dd")
              (checksum-error .
               #f)
              (conflicts .
@@ -58336,7 +58352,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/cf14b039901df7ede55fa128e206679f44d2f9dd/racket-win32-x86_64-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -58410,7 +58426,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "3dff4171c999fbd84f8a4af38446502eeff0ec04")
              (checksum-error .
               #f)
              (conflicts .
@@ -58443,7 +58459,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/3dff4171c999fbd84f8a4af38446502eeff0ec04/racket-x86_64-linux-natipkg-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -58517,7 +58533,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "ba9215b58db4c38ad60d0fc788f51ff740d79858")
              (checksum-error .
               #f)
              (conflicts .
@@ -58550,7 +58566,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "https://pkg-sources.racket-lang.org/pkgs/empty.zip")
+              "https://pkg-sources.racket-lang.org/pkgs/ba9215b58db4c38ad60d0fc788f51ff740d79858/racket-x86_64-macosx-2.zip")
              (tags .
               ("main-distribution"))
              (versions .
@@ -62131,7 +62147,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "4829323916d295d4d11faa9af9b60303b599e872")
              (checksum-error .
               #f)
              (conflicts .
@@ -62154,6 +62170,8 @@
               ())
              (name .
               "remote-shell")
+             (nix-sha256 .
+              "02mkd149cxqwnm68qdb6jiyfrjb7ifcmh6xdssx665dazdn0390j")
              (ring .
               0)
              (search-terms .
@@ -62164,7 +62182,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/remote-shell/?path=remote-shell")
              (tags .
               ())
              (versions .
@@ -62219,7 +62237,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "4829323916d295d4d11faa9af9b60303b599e872")
              (checksum-error .
               #f)
              (conflicts .
@@ -62242,6 +62260,8 @@
               ((lib "remote-shell/remote-shell.scrbl")))
              (name .
               "remote-shell-doc")
+             (nix-sha256 .
+              "02mkd149cxqwnm68qdb6jiyfrjb7ifcmh6xdssx665dazdn0390j")
              (ring .
               0)
              (search-terms .
@@ -62252,7 +62272,7 @@
                     (ring:0 .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/remote-shell/?path=remote-shell-doc")
              (tags .
               ())
              (versions .
@@ -64325,7 +64345,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "39580725993288d4f8495fd988f3d99e8db60613")
+              "f21ce268bca7aabbebc70f9fb10703351cbcf02b")
              (checksum-error .
               #f)
              (conflicts .
@@ -64349,7 +64369,7 @@
              (name .
               "rsound")
              (nix-sha256 .
-              "03q03s60lj365k9nwiglnzdyxmn8j4rq2y7nf4k8z432cym0vv33")
+              "1rfq40h4al5qaj9pggbrf1aiqyx8943kn1q0h1rmsc9dnhxxxaj7")
              (ring .
               1)
              (search-terms .
@@ -64364,7 +64384,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "github://github.com/jbclements/RSound/pre-6/")
+              "github://github.com/jbclements/RSound/master/")
              (tags .
               ("audio" "ffi" "io"))
              (versions .
@@ -69465,7 +69485,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "e87aa767038b78386d18e3c0af8e9a482ca6e421")
+              "744bf37d7a347a55d1ec72885f87d35919f68b7b")
              (checksum-error .
               #f)
              (conflicts .
@@ -69489,7 +69509,7 @@
              (name .
               "socketcan")
              (nix-sha256 .
-              "01rn39gsr5ipirgvga8ps9d1433f3n8wyrxqbpfygf2py8rm4nik")
+              "0y005rgkkbaly7z6k40pprj8icxrad5qifh77zy847sd0cg4lciv")
              (ring .
               1)
              (search-terms .
@@ -69500,7 +69520,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "github://github.com/abencz/racket-socketcan/racket_5.3.6")
+              "git://github.com/abencz/racket-socketcan#master")
              (tags .
               ())
              (versions .
@@ -76513,7 +76533,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "abed5715993ec2e53d201d55c3c9b57be30874fc")
+              "de68f80c91b47b5860709a0bb31b462b8300eb09")
              (checksum-error .
               #f)
              (conflicts .
@@ -76537,7 +76557,7 @@
              (name .
               "threading")
              (nix-sha256 .
-              "1yd0lqndzpybisj288p1d9z9n5jml10xcd2q2hfdlp8dnpwrqvlb")
+              "03c7z97nn3l6033g99hhjmywrksf3ii4617kxnla8q8jsjpwzf81")
              (ring .
               1)
              (search-terms .
@@ -76550,7 +76570,7 @@
                     (ring:1 .
                      #t)))
              (source .
-              "git://github.com/lexi-lambda/threading#compatibility-5.3.2-to-6.1")
+              "git://github.com/lexi-lambda/threading?path=threading")
              (tags .
               ())
              (versions .
@@ -80295,7 +80315,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "480535837da0cc72112b9edc601885620ba8a55d")
              (checksum-error .
               #f)
              (conflicts .
@@ -80318,6 +80338,8 @@
               ())
              (name .
               "unstable")
+             (nix-sha256 .
+              "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s")
              (ring .
               0)
              (search-terms .
@@ -80334,7 +80356,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable/?path=unstable")
              (tags .
               ("unstable"))
              (versions .
@@ -80389,7 +80411,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "abe368e38bf860c607a6b11c212e86519ac8f80e")
              (checksum-error .
               #f)
              (conflicts .
@@ -80412,6 +80434,8 @@
               ((lib "unstable/2d/lang/reader.rkt") (lib "unstable/2d/cond.rkt") (lib "unstable/2d/match.rkt") (lib "unstable/2d/tabular.rkt") (lib "unstable/2d/dir-chars.rkt")))
              (name .
               "unstable-2d")
+             (nix-sha256 .
+              "1vdhglzwzljy03ca4b6h9mdfk6wz89cgyplapiy4xc1ijxh3197l")
              (ring .
               0)
              (search-terms .
@@ -80422,7 +80446,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-2d")
              (tags .
               ("unstable"))
              (versions .
@@ -80477,7 +80501,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "36f4e320c574cef6630ec34ac73f69a2911b86b0")
              (checksum-error .
               #f)
              (conflicts .
@@ -80500,6 +80524,8 @@
               ((lib "unstable/contract.rkt")))
              (name .
               "unstable-contract-lib")
+             (nix-sha256 .
+              "1m8rp3kqfg6lmm96hlaknns0014dvixik6sm4qxjsf80dfvp57wf")
              (ring .
               0)
              (search-terms .
@@ -80512,7 +80538,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-contract-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -80567,7 +80593,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "f72727898e9a59429eeb419752f5c55926d1a6c4")
              (checksum-error .
               #f)
              (conflicts .
@@ -80590,6 +80616,8 @@
               ((lib "unstable/debug.rkt")))
              (name .
               "unstable-debug-lib")
+             (nix-sha256 .
+              "195bjfbgf42gbrdpay4zscwlq493xpnaik683vzmqms3akdykhxl")
              (ring .
               0)
              (search-terms .
@@ -80600,7 +80628,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-debug-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -80655,7 +80683,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "480535837da0cc72112b9edc601885620ba8a55d")
              (checksum-error .
               #f)
              (conflicts .
@@ -80678,6 +80706,8 @@
               ((lib "unstable/scribblings/find.scrbl") (lib "unstable/scribblings/class-iop.scrbl") (lib "unstable/scribblings/match.scrbl") (lib "unstable/scribblings/logging.scrbl") (lib "unstable/scribblings/gui/pict.scrbl") (lib "unstable/scribblings/sandbox.scrbl") (lib "unstable/scribblings/automata.scrbl") (lib "unstable/scribblings/contract.scrbl") (lib "unstable/scribblings/options.scrbl") (lib "unstable/scribblings/struct.scrbl") (lib "unstable/scribblings/custom-write.scrbl") (lib "unstable/scribblings/wrapc.scrbl") (lib "unstable/scribblings/macro-testing.scrbl") (lib "unstable/scribblings/unstable.scrbl") (lib "unstable/scribblings/string.scrbl") (lib "unstable/scribblings/gui/unstable-gui.scrbl") (lib "unstable/scribblings/gui/prefs.scrbl") (lib "unstable/scribblings/socket.scrbl") (lib "unstable/scribblings/syntax.scrbl") (lib "unstable/scribblings/pretty.scrbl") (lib "unstable/scribblings/temp-c.scrbl") (lib "unstable/scribblings/utils.rkt") (lib "unstable/scribblings/function.scrbl") (lib "unstable/scribblings/open-place.scrbl") (lib "unstable/scribblings/markparam.scrbl") (lib "unstable/scribblings/error.scrbl") (lib "unstable/scribblings/recontract.scrbl") (lib "unstable/scribblings/lazy-require.scrbl") (lib "unstable/scribblings/hash.scrbl") (lib "unstable/scribblings/parameter-group.scrbl") (lib "unstable/scribblings/debug.scrbl") (lib "unstable/scribblings/sequence.scrbl") (lib "unstable/scribblings/future.scrbl") (lib "unstable/scribblings/gui/scribble.scrbl") (lib "unstable/scribblings/2d.scrbl") (lib "unstable/scribblings/gui/notify.scrbl") (lib "unstable/scribblings/gui/snip.scrbl") (lib "unstable/scribblings/define.scrbl") (lib "unstable/scribblings/gui/slideshow.scrbl") (lib "unstable/scribblings/list.scrbl") (lib "unstable/scribblings/bytes.scrbl")))
              (name .
               "unstable-doc")
+             (nix-sha256 .
+              "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s")
              (ring .
               0)
              (search-terms .
@@ -80694,7 +80724,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable/?path=unstable-doc")
              (tags .
               ("unstable"))
              (versions .
@@ -80749,7 +80779,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "7071d9a3ee0ad60f947c0a597ddd4b64bed3d94a")
              (checksum-error .
               #f)
              (conflicts .
@@ -80772,6 +80802,8 @@
               ((lib "unstable/unstable-flonum.scrbl")))
              (name .
               "unstable-flonum-doc")
+             (nix-sha256 .
+              "0ll6mqmyi3pisgpnv8ilji90c91d2kzc6bhqiyqqrm8930kymqld")
              (ring .
               0)
              (search-terms .
@@ -80782,7 +80814,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-flonum/?path=unstable-flonum-doc")
              (tags .
               ("unstable"))
              (versions .
@@ -80837,7 +80869,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "7071d9a3ee0ad60f947c0a597ddd4b64bed3d94a")
              (checksum-error .
               #f)
              (conflicts .
@@ -80860,6 +80892,8 @@
               ((lib "unstable/flonum.rkt")))
              (name .
               "unstable-flonum-lib")
+             (nix-sha256 .
+              "0ll6mqmyi3pisgpnv8ilji90c91d2kzc6bhqiyqqrm8930kymqld")
              (ring .
               0)
              (search-terms .
@@ -80870,7 +80904,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-flonum/?path=unstable-flonum-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -80925,7 +80959,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "3bd435890dae3365abe90fd1b5f7c62837e3801e")
              (checksum-error .
               #f)
              (conflicts .
@@ -80948,6 +80982,8 @@
               ((lib "unstable/latent-contract/defthing.rkt") (lib "unstable/latent-contract.rkt") (lib "unstable/latent-contract/serialize-syntax.rkt")))
              (name .
               "unstable-latent-contract-lib")
+             (nix-sha256 .
+              "0wv0kh6mr97yz16yy3f3zkc7pv1f2jvc41jqs5wlilb7dkqz0csc")
              (ring .
               0)
              (search-terms .
@@ -80960,7 +80996,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-latent-contract-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -81015,7 +81051,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "480535837da0cc72112b9edc601885620ba8a55d")
              (checksum-error .
               #f)
              (conflicts .
@@ -81038,6 +81074,8 @@
               ((lib "unstable/gui/notify.rkt") (lib "unstable/automata/re-ext.rkt") (lib "unstable/gui/slideshow.rkt") (lib "unstable/wrapc.rkt") (lib "unstable/gui/scribble.rkt") (lib "unstable/gui/snip.rkt") (lib "unstable/logging.rkt") (lib "unstable/find.rkt") (lib "unstable/string.rkt") (lib "unstable/gui/ppict.rkt") (lib "unstable/syntax.rkt") (lib "unstable/match.rkt") (lib "unstable/automata/nfa.rkt") (lib "unstable/lazy-require.rkt") (lib "unstable/gui/pslide.rkt") (lib "unstable/future.rkt") (lib "unstable/define.rkt") (lib "unstable/automata/re.rkt") (lib "unstable/temp-c/dsl.rkt") (lib "unstable/arrow.rkt") (lib "unstable/automata/machine.rkt") (lib "unstable/socket.rkt") (lib "unstable/automata/nfa-ep.rkt") (lib "unstable/gui/pict/plt-logo.rkt") (lib "unstable/gui/prefs.rkt") (lib "unstable/custom-write.rkt") (lib "unstable/sequence.rkt") (lib "unstable/time.rkt") (lib "unstable/gui/pict/align.rkt") (lib "unstable/error.rkt") (lib "unstable/struct.rkt") (lib "unstable/markparam.rkt") (lib "unstable/recontract.rkt") (lib "unstable/gui/pict.rkt") (lib "unstable/open-place.rkt") (lib "unstable/sandbox.rkt") (lib "unstable/automata/dfa.rkt") (lib "unstable/temp-c/monitor.rkt")))
              (name .
               "unstable-lib")
+             (nix-sha256 .
+              "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s")
              (ring .
               0)
              (search-terms .
@@ -81054,7 +81092,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable/?path=unstable-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -81109,7 +81147,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "a328c5e663072779f70a42a722d2c3e9f2c430c3")
              (checksum-error .
               #f)
              (conflicts .
@@ -81132,6 +81170,8 @@
               ((lib "unstable/bytes.rkt") (lib "unstable/hash.rkt") (lib "unstable/class-iop.rkt") (lib "unstable/list.rkt") (lib "unstable/function.rkt")))
              (name .
               "unstable-list-lib")
+             (nix-sha256 .
+              "1vjccqyqysbkb45j5nrdgl3i92vzy99g1mh303lr5gh72h6v6b4h")
              (ring .
               0)
              (search-terms .
@@ -81144,7 +81184,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-list-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -81199,7 +81239,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "92c7c6d8fb35f17fb74ab4f2ad995f487cca0d96")
              (checksum-error .
               #f)
              (conflicts .
@@ -81222,6 +81262,8 @@
               ((lib "unstable/macro-testing.rkt")))
              (name .
               "unstable-macro-testing-lib")
+             (nix-sha256 .
+              "03x9vl9i2sr4v41wik5zaxljy40dw4srxkbbakskisz8sw25w6q6")
              (ring .
               0)
              (search-terms .
@@ -81232,7 +81274,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-macro-testing-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -81287,7 +81329,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "1063efe9e8f02ecdf8aefd6200d759ba1f0e8d5c")
              (checksum-error .
               #f)
              (conflicts .
@@ -81310,6 +81352,8 @@
               ((lib "unstable/options.rkt")))
              (name .
               "unstable-options-lib")
+             (nix-sha256 .
+              "1msq3fqsrqxx93yc1fp7v1wh2bjak19jkkd7i008867hclvw8p5z")
              (ring .
               0)
              (search-terms .
@@ -81322,7 +81366,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-options-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -81377,7 +81421,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "30de3acb3487c9c3ed4e8ef664ca18bb9667be09")
              (checksum-error .
               #f)
              (conflicts .
@@ -81400,6 +81444,8 @@
               ((lib "unstable/parameter-group.rkt")))
              (name .
               "unstable-parameter-group-lib")
+             (nix-sha256 .
+              "1bxwkf6j6pkm1j4wx6ypx6qs82mgiq0vc00n50brrh72sf4qdv2w")
              (ring .
               0)
              (search-terms .
@@ -81412,7 +81458,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-parameter-group-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -81467,7 +81513,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "5d6d24be2b0a9c773ac30a22c870b7817ce9f90a")
              (checksum-error .
               #f)
              (conflicts .
@@ -81490,6 +81536,8 @@
               ((lib "unstable/pretty.rkt")))
              (name .
               "unstable-pretty-lib")
+             (nix-sha256 .
+              "02nv3l1x0fljqr5isrxf98z25zm3jpjfjiy6827g37vwc7iq6d7r")
              (ring .
               0)
              (search-terms .
@@ -81500,7 +81548,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-pretty-lib")
              (tags .
               ("unstable"))
              (versions .
@@ -81555,7 +81603,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "a132a56200d99be9e3cec3928d8580559402beb6")
              (checksum-error .
               #f)
              (conflicts .
@@ -81578,6 +81626,8 @@
               ((lib "unstable/gui/redex.rkt") (lib "unstable/gui/unstable-redex.scrbl")))
              (name .
               "unstable-redex")
+             (nix-sha256 .
+              "0f45vjk67hc4fcjpxqmpfrmg8qlzvgsnmx801ifyg74v48dw3s2m")
              (ring .
               0)
              (search-terms .
@@ -81588,7 +81638,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable-redex")
              (tags .
               ("unstable"))
              (versions .
@@ -81643,7 +81693,7 @@
                     (test-success-log .
                      #f)))
              (checksum .
-              "9f098dddde7f217879070816090c1e8e74d49432")
+              "480535837da0cc72112b9edc601885620ba8a55d")
              (checksum-error .
               #f)
              (conflicts .
@@ -81666,6 +81716,8 @@
               ((lib "tests/test-docs-complete.rkt") (lib "tests/unstable/sequence.rkt") (lib "tests/unstable/debug.rkt") (lib "tests/unstable/planet-syntax.rkt") (lib "tests/unstable/logging.rkt") (lib "tests/unstable/match.rkt") (lib "tests/unstable/set.rkt") (lib "tests/unstable/helpers.rkt") (lib "tests/unstable/parameter-group.rkt") (lib "tests/unstable/syntax.rkt") (lib "tests/unstable/list.rkt") (lib "tests/unstable/contract.rkt")))
              (name .
               "unstable-test")
+             (nix-sha256 .
+              "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s")
              (ring .
               0)
              (search-terms .
@@ -81684,7 +81736,7 @@
                     (unstable .
                      #t)))
              (source .
-              "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip")
+              "git://github.com/racket/unstable/?path=unstable-test")
              (tags .
               ("unstable"))
              (versions .

--- a/nixpkgs/bump.sh
+++ b/nixpkgs/bump.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env nix-shell
-#! nix-shell --quiet -p bash gawk git nix-prefetch-git -i bash
+#! nix-shell --quiet -p bash gawk git nix -i bash
 
 set -euo pipefail
 
-URL=https://github.com/NixOS/nixpkgs-channels.git
+BASE_URL=https://github.com/NixOS/nixpkgs-channels
 DEFAULT_REV=refs/heads/nixpkgs-unstable
+NAME=nixpkgs
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 rev=${1:-$DEFAULT_REV}
 
 if (( ${#rev} != 40 )); then
-  rev=$(git ls-remote $URL | awk '$2 == "'"$rev"'" { print $1 }')
+  rev=$(git ls-remote $BASE_URL "$rev" | awk '$2 == "'"$rev"'" { print $1 }')
 fi
 
-nix-prefetch-git --no-deepClone $URL $rev > default.json.new
+url=$BASE_URL/archive/$rev.tar.gz
+sha256=$(nix-prefetch-url --unpack --name $NAME "$url")
+cat > default.json.new <<EOF
+{
+  "name": "$NAME",
+  "url": "$url",
+  "sha256": "$sha256",
+  "unpack": true
+}
+EOF
+
 mv default.json{.new,}

--- a/nixpkgs/default.json
+++ b/nixpkgs/default.json
@@ -1,7 +1,6 @@
 {
-  "url": "https://github.com/NixOS/nixpkgs-channels.git",
-  "rev": "1bf18e4c852c52e13842e71f70dec1752bb4297b",
-  "date": "2018-11-23T13:46:40+01:00",
+  "name": "source",
+  "url": "https://github.com/NixOS/nixpkgs-channels/archive/1bf18e4c852c52e13842e71f70dec1752bb4297b.tar.gz",
   "sha256": "1hw8czvgismzmr79rwhfm3dv98x5nbql98gwvnmmbbzj60sb7vpm",
-  "fetchSubmodules": false
+  "unpack": true
 }

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,2 +1,2 @@
-(import <nixpkgs> {}).fetchgit
-  (builtins.removeAttrs (builtins.fromJSON (builtins.readFile ./default.json)) [ "date" ])
+import <nix/fetchurl.nix>
+(builtins.fromJSON (builtins.readFile ./default.json))

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -3478,9 +3478,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "distributed-places-test" = self.lib.mkRacketDerivation rec {
   pname = "distributed-places-test";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "distributed-places-test";
+    src = fetchgit {
+    name = "distributed-places-test";
+    url = "git://github.com/racket/distributed-places.git";
+    rev = "490ee40e32cbaa818798aacca89fe4e3b3fc772b";
+    sha256 = "009sflz25ps7mj07slv1gw3z9i6b3wzpyxaxn8ji0wbry02w0vvd";
+  };
   };
   racketBuildInputs = [ self."base" self."distributed-places-lib" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3488,9 +3493,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "distro-build" = self.lib.mkRacketDerivation rec {
   pname = "distro-build";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "distro-build";
+    src = fetchgit {
+    name = "distro-build";
+    url = "git://github.com/racket/distro-build.git";
+    rev = "2338b6dbb7c4b3c4ad35917a09eb173059387668";
+    sha256 = "1qpr6hc8z60y9ngg0v54cp4wri5z3ng4ns7yabnrdccacylwvk19";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."distro-build-client" self."distro-build-doc" self."distro-build-lib" self."distro-build-server" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."ds-store-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."plt-web-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."remote-shell-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -3678,8 +3688,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-i386-macosx" = self.lib.mkRacketDerivation rec {
   pname = "draw-i386-macosx";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/8632512357c53d2d085a68545b2e093a9f9677be/draw-i386-macosx.zip";
+    sha1 = "8632512357c53d2d085a68545b2e093a9f9677be";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3688,8 +3698,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-i386-macosx-2" = self.lib.mkRacketDerivation rec {
   pname = "draw-i386-macosx-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/ecd61bfff1daa6e72ab14c73bfa480499717da29/draw-i386-macosx-2.zip";
+    sha1 = "ecd61bfff1daa6e72ab14c73bfa480499717da29";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3718,8 +3728,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-ppc-macosx" = self.lib.mkRacketDerivation rec {
   pname = "draw-ppc-macosx";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/552c18b393b3377b051da48aef8b8d6883615029/draw-ppc-macosx.zip";
+    sha1 = "552c18b393b3377b051da48aef8b8d6883615029";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3728,8 +3738,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-ppc-macosx-2" = self.lib.mkRacketDerivation rec {
   pname = "draw-ppc-macosx-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/a68c25d5794dff8f4f46eaccea942d2f04f32ca3/draw-ppc-macosx-2.zip";
+    sha1 = "a68c25d5794dff8f4f46eaccea942d2f04f32ca3";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3768,8 +3778,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-win32-i386" = self.lib.mkRacketDerivation rec {
   pname = "draw-win32-i386";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/915598defe21a2213c2833b45ace0c62fa31b39e/draw-win32-i386.zip";
+    sha1 = "915598defe21a2213c2833b45ace0c62fa31b39e";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3778,8 +3788,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-win32-i386-2" = self.lib.mkRacketDerivation rec {
   pname = "draw-win32-i386-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/3f5fb8b2e1ce9802a71328ee338e277573eb9cc9/draw-win32-i386-2.zip";
+    sha1 = "3f5fb8b2e1ce9802a71328ee338e277573eb9cc9";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3798,8 +3808,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-win32-x86_64" = self.lib.mkRacketDerivation rec {
   pname = "draw-win32-x86_64";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/d5769e02a39715de02b3c91c55a4d366dbbcb7fd/draw-win32-x86_64.zip";
+    sha1 = "d5769e02a39715de02b3c91c55a4d366dbbcb7fd";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3808,8 +3818,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-win32-x86_64-2" = self.lib.mkRacketDerivation rec {
   pname = "draw-win32-x86_64-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/c6c2edb3e086033e24a8121d85675f1bc11b7705/draw-win32-x86_64-2.zip";
+    sha1 = "c6c2edb3e086033e24a8121d85675f1bc11b7705";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3838,8 +3848,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-x86_64-linux-natipkg-2" = self.lib.mkRacketDerivation rec {
   pname = "draw-x86_64-linux-natipkg-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/bbbbcdc28aa69e11c7d7796d6796f34acf48b8e9/draw-x86_64-linux-natipkg-2.zip";
+    sha1 = "bbbbcdc28aa69e11c7d7796d6796f34acf48b8e9";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3858,8 +3868,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-x86_64-macosx" = self.lib.mkRacketDerivation rec {
   pname = "draw-x86_64-macosx";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/d47568a60e3e12793f2c49b322ad49c2a8ec8d26/draw-x86_64-macosx.zip";
+    sha1 = "d47568a60e3e12793f2c49b322ad49c2a8ec8d26";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -3868,8 +3878,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "draw-x86_64-macosx-2" = self.lib.mkRacketDerivation rec {
   pname = "draw-x86_64-macosx-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/552725bedd421a4c9979c639b5082ea0352f9ee6/draw-x86_64-macosx-2.zip";
+    sha1 = "552725bedd421a4c9979c639b5082ea0352f9ee6";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -5605,9 +5615,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "gui-pkg-manager" = self.lib.mkRacketDerivation rec {
   pname = "gui-pkg-manager";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "gui-pkg-manager";
+    src = fetchgit {
+    name = "gui-pkg-manager";
+    url = "git://github.com/racket/gui-pkg-manager.git";
+    rev = "eb80f658a4b35757687eb26fa48a16d57685ef82";
+    sha256 = "1f59a35lw537h5gcg8mhif70mmhaa0kmfw4i6bwv4d15pz3zzrlf";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-doc" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -5615,9 +5630,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "gui-pkg-manager-doc" = self.lib.mkRacketDerivation rec {
   pname = "gui-pkg-manager-doc";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "gui-pkg-manager-doc";
+    src = fetchgit {
+    name = "gui-pkg-manager-doc";
+    url = "git://github.com/racket/gui-pkg-manager.git";
+    rev = "eb80f658a4b35757687eb26fa48a16d57685ef82";
+    sha256 = "1f59a35lw537h5gcg8mhif70mmhaa0kmfw4i6bwv4d15pz3zzrlf";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -5700,8 +5720,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     src = fetchgit {
     name = "hackett";
     url = "git://github.com/lexi-lambda/hackett.git";
-    rev = "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f";
-    sha256 = "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq";
+    rev = "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea";
+    sha256 = "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib";
   };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."curly-fn-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."hackett-doc" self."hackett-lib" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."namespaced-transformer-lib" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-classes-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."threading-lib" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
@@ -5715,8 +5735,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     src = fetchgit {
     name = "hackett-demo";
     url = "git://github.com/lexi-lambda/hackett.git";
-    rev = "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f";
-    sha256 = "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq";
+    rev = "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea";
+    sha256 = "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib";
   };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."class-iop-lib" self."compatibility-lib" self."curly-fn-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."hackett-lib" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."namespaced-transformer-lib" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."plai-lib" self."planet-lib" self."r5rs-lib" self."r6rs-lib" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-classes-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."threading-lib" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" ];
@@ -5730,8 +5750,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     src = fetchgit {
     name = "hackett-doc";
     url = "git://github.com/lexi-lambda/hackett.git";
-    rev = "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f";
-    sha256 = "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq";
+    rev = "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea";
+    sha256 = "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib";
   };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."curly-fn-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."hackett-lib" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."namespaced-transformer-lib" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-classes-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."threading-lib" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
@@ -5745,8 +5765,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     src = fetchgit {
     name = "hackett-lib";
     url = "git://github.com/lexi-lambda/hackett.git";
-    rev = "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f";
-    sha256 = "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq";
+    rev = "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea";
+    sha256 = "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib";
   };
   };
   racketBuildInputs = [ self."base" self."curly-fn-lib" self."data-lib" self."namespaced-transformer-lib" self."racket-lib" self."rackunit-lib" self."syntax-classes-lib" self."testing-util-lib" self."threading-lib" ];
@@ -5760,8 +5780,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     src = fetchgit {
     name = "hackett-test";
     url = "git://github.com/lexi-lambda/hackett.git";
-    rev = "8e4e0e904ac37df58b8c8ef29c0f94ad4151246f";
-    sha256 = "0f1darb65qpbdr0f1r4hbbw6g1b55h9fkfhywxnsyw8z2rzc2rpq";
+    rev = "f5a080ebcf9e2ca1fbf5be98517f4991ec2405ea";
+    sha256 = "0rfwrm6ddrwzc1j4x8sd1ld5lmnmj9qg34mhknmfi1jn28ya2zib";
   };
   };
   racketBuildInputs = [ self."base" self."curly-fn-lib" self."data-lib" self."errortrace-lib" self."hackett-lib" self."namespaced-transformer-lib" self."racket-lib" self."rackunit-lib" self."sandbox-lib" self."scheme-lib" self."source-syntax" self."syntax-classes-lib" self."testing-util-lib" self."threading-lib" ];
@@ -5785,8 +5805,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   src = fetchgit {
     name = "handin";
     url = "git://github.com/plt/handin.git";
-    rev = "3c31daccf0f61bb06aa65e36d72acc0ef2f453da";
-    sha256 = "09vqljgvz43gymc2q4i40mg551xxhb9pf4zkgnprdrvjhi6ihdss";
+    rev = "233b17e820bdd9b859f551bf4714204718d04306";
+    sha256 = "1n46sj9wxq22gqbn1jd3q4pjhf3vmdxix5lji2h5zffa0rmakyda";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-doc" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -5917,9 +5937,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "honu" = self.lib.mkRacketDerivation rec {
   pname = "honu";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "honu";
+    url = "git://github.com/racket/honu.git";
+    rev = "fd89d2af7df5aa3db770049663437484d7700820";
+    sha256 = "10ph1fj376drx8p9g4ak5cdjrhmjgwpd4w7h334b6fx4aja2bkss";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -10137,8 +10159,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   src = fetchgit {
     name = "plai-typed";
     url = "git://github.com/mflatt/plai-typed.git";
-    rev = "e11e7e4cd655b958296055f490ea8eadf5ea5ce7";
-    sha256 = "1sc9xjnqrkq1fv6ymlbln1cnbpw8sxzlwwi93scl8ngqq1wdvff2";
+    rev = "582728d7a724674b58c6af8d2b20a6513947152a";
+    sha256 = "03bqrf53ll6yzzh41slmdaqsffpi92wsshj8vy2i36mbkc7rzy15";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai" self."plai-doc" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-doc" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -10149,8 +10171,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   src = fetchgit {
     name = "plai-typed-s-exp-match";
     url = "git://github.com/mflatt/plai-typed-s-exp-match.git";
-    rev = "e010d9718916394b1b3545cb2f7a49c27904e873";
-    sha256 = "1rfa6zxngx1x011m7vlizrs6v6r6vn586icwzh0m0gj077dwslww";
+    rev = "ff05b257cc8739d2f4ad8f33b65440635ab9cce0";
+    sha256 = "0k2knsg04s641aw4gn5ncwbvjp973px0jrm919vxy8gdizlvri22";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai" self."plai-doc" self."plai-lib" self."plai-typed" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-doc" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -10342,9 +10364,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "plt-services" = self.lib.mkRacketDerivation rec {
   pname = "plt-services";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "pkgs/plt-services";
+    src = fetchgit {
+    name = "plt-services";
+    url = "git://github.com/racket/racket.git";
+    rev = "cb8fde7a9e5fad41e4f90ecca5f92921fdc00a52";
+    sha256 = "10kmcq77wjrf5maimbc6ac6c34xvmf45cb8l3k35alz2kag3i07x";
+  };
   };
   racketBuildInputs = [  ];
   circularBuildInputs = [  ];
@@ -10352,9 +10379,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "plt-web" = self.lib.mkRacketDerivation rec {
   pname = "plt-web";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "plt-web";
+    src = fetchgit {
+    name = "plt-web";
+    url = "git://github.com/racket/plt-web.git";
+    rev = "5697a81d84117f9341686783b02299f74656918a";
+    sha256 = "0hzrp84cg3gl489y9nidzjqdya64wkqd48w2rlarv3w5ldw0nppl";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."plt-web-doc" self."plt-web-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-doc" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -10362,9 +10394,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "plt-web-doc" = self.lib.mkRacketDerivation rec {
   pname = "plt-web-doc";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "plt-web-doc";
+    src = fetchgit {
+    name = "plt-web-doc";
+    url = "git://github.com/racket/plt-web.git";
+    rev = "5697a81d84117f9341686783b02299f74656918a";
+    sha256 = "0hzrp84cg3gl489y9nidzjqdya64wkqd48w2rlarv3w5ldw0nppl";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."plt-web-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-doc" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -10616,8 +10653,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   src = fetchgit {
     name = "portaudio";
     url = "git://github.com/jbclements/portaudio.git";
-    rev = "74dfaf1d6317a9f5479ae5492e874e9e73888a46";
-    sha256 = "1zczwx2z5kw85h15bw3xikwnjb4mxw4n4g8x7wkzqfrkvll8xmsb";
+    rev = "3703edda0c6b9f5ef7e7bf39b933cb1d0e9a82b5";
+    sha256 = "1132wfqdapn7yswhkp7rbvc6lymqs1wgala8rnka92j6z5ms8rln";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -11317,8 +11354,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-i386-macosx-2" = self.lib.mkRacketDerivation rec {
   pname = "racket-i386-macosx-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/2b0a4a12fc5fc8a304bcba60c09af2f8b75988c5/racket-i386-macosx-2.zip";
+    sha1 = "2b0a4a12fc5fc8a304bcba60c09af2f8b75988c5";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -11420,8 +11457,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-ppc-macosx-2" = self.lib.mkRacketDerivation rec {
   pname = "racket-ppc-macosx-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/a36e58d540359092d684bd3a277d0068cff04afa/racket-ppc-macosx-2.zip";
+    sha1 = "a36e58d540359092d684bd3a277d0068cff04afa";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -11576,8 +11613,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-win32-i386" = self.lib.mkRacketDerivation rec {
   pname = "racket-win32-i386";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/c57a6dae91081a4284d329364ad566c108d84747/racket-win32-i386.zip";
+    sha1 = "c57a6dae91081a4284d329364ad566c108d84747";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -11586,8 +11623,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-win32-i386-2" = self.lib.mkRacketDerivation rec {
   pname = "racket-win32-i386-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/5eeac0afec99043631567829e4450694c1a913e2/racket-win32-i386-2.zip";
+    sha1 = "5eeac0afec99043631567829e4450694c1a913e2";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -11606,8 +11643,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-win32-x86_64" = self.lib.mkRacketDerivation rec {
   pname = "racket-win32-x86_64";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/1026e430bb077a696084e702f5e8889f5b7dd55e/racket-win32-x86_64.zip";
+    sha1 = "1026e430bb077a696084e702f5e8889f5b7dd55e";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -11616,8 +11653,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-win32-x86_64-2" = self.lib.mkRacketDerivation rec {
   pname = "racket-win32-x86_64-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/cf14b039901df7ede55fa128e206679f44d2f9dd/racket-win32-x86_64-2.zip";
+    sha1 = "cf14b039901df7ede55fa128e206679f44d2f9dd";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -11636,8 +11673,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-x86_64-linux-natipkg-2" = self.lib.mkRacketDerivation rec {
   pname = "racket-x86_64-linux-natipkg-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/3dff4171c999fbd84f8a4af38446502eeff0ec04/racket-x86_64-linux-natipkg-2.zip";
+    sha1 = "3dff4171c999fbd84f8a4af38446502eeff0ec04";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -11656,8 +11693,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   "racket-x86_64-macosx-2" = self.lib.mkRacketDerivation rec {
   pname = "racket-x86_64-macosx-2";
   src = fetchurl {
-    url = "https://pkg-sources.racket-lang.org/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+    url = "https://pkg-sources.racket-lang.org/pkgs/ba9215b58db4c38ad60d0fc788f51ff740d79858/racket-x86_64-macosx-2.zip";
+    sha1 = "ba9215b58db4c38ad60d0fc788f51ff740d79858";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -12419,9 +12456,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "remote-shell" = self.lib.mkRacketDerivation rec {
   pname = "remote-shell";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "remote-shell";
+    src = fetchgit {
+    name = "remote-shell";
+    url = "git://github.com/racket/remote-shell.git";
+    rev = "4829323916d295d4d11faa9af9b60303b599e872";
+    sha256 = "02mkd149cxqwnm68qdb6jiyfrjb7ifcmh6xdssx665dazdn0390j";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."remote-shell-doc" self."remote-shell-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -12429,9 +12471,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "remote-shell-doc" = self.lib.mkRacketDerivation rec {
   pname = "remote-shell-doc";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "remote-shell-doc";
+    src = fetchgit {
+    name = "remote-shell-doc";
+    url = "git://github.com/racket/remote-shell.git";
+    rev = "4829323916d295d4d11faa9af9b60303b599e872";
+    sha256 = "02mkd149cxqwnm68qdb6jiyfrjb7ifcmh6xdssx665dazdn0390j";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."remote-shell-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -12775,8 +12822,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   src = fetchgit {
     name = "rsound";
     url = "git://github.com/jbclements/RSound.git";
-    rev = "39580725993288d4f8495fd988f3d99e8db60613";
-    sha256 = "03q03s60lj365k9nwiglnzdyxmn8j4rq2y7nf4k8z432cym0vv33";
+    rev = "f21ce268bca7aabbebc70f9fb10703351cbcf02b";
+    sha256 = "1rfq40h4al5qaj9pggbrf1aiqyx8943kn1q0h1rmsc9dnhxxxaj7";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."memoize" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."portaudio" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -13813,9 +13860,9 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   pname = "socketcan";
   src = fetchgit {
     name = "socketcan";
-    url = "git://github.com/abencz/racket-socketcan.git";
-    rev = "e87aa767038b78386d18e3c0af8e9a482ca6e421";
-    sha256 = "01rn39gsr5ipirgvga8ps9d1433f3n8wyrxqbpfygf2py8rm4nik";
+    url = "git://github.com/abencz/racket-socketcan";
+    rev = "744bf37d7a347a55d1ec72885f87d35919f68b7b";
+    sha256 = "0y005rgkkbaly7z6k40pprj8icxrad5qifh77zy847sd0cg4lciv";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."make" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -15120,11 +15167,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "threading" = self.lib.mkRacketDerivation rec {
   pname = "threading";
-  src = fetchgit {
+  src = self.lib.extractPath {
+    path = "threading";
+    src = fetchgit {
     name = "threading";
-    url = "git://github.com/lexi-lambda/threading";
-    rev = "abed5715993ec2e53d201d55c3c9b57be30874fc";
-    sha256 = "1yd0lqndzpybisj288p1d9z9n5jml10xcd2q2hfdlp8dnpwrqvlb";
+    url = "git://github.com/lexi-lambda/threading.git";
+    rev = "de68f80c91b47b5860709a0bb31b462b8300eb09";
+    sha256 = "03c7z97nn3l6033g99hhjmywrksf3ii4617kxnla8q8jsjpwzf81";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."alexis-util+auto-syntax-e+scope-operations+scribble-math+stxp..." self."at-exp-lib" self."backport-template-pr1514" self."base" self."cext-lib" self."class-iop-lib" self."collections-lib+functional-lib+match-plus+static-rename+stati..." self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."curly-fn-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."debug-scopes" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."fancy-app+kw-make-struct+lang-file+lens-common+lens-data+repr..." self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."hyper-literate" self."icons" self."images-gui-lib" self."images-lib" self."kw-utils" self."macro-debugger-text-lib" self."match-plus" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."mutable-match-lambda" self."namespaced-transformer-lib" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."phc-toolkit" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."predicates" self."pretty-format" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackjure" self."rackunit-doc" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."reprovide-lang" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-doc" self."scribble-enhanced" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."sexp-diff" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."static-rename" self."static-rename-lib" self."string-constants-lib" self."struct-update-lib" self."sweet-exp-lib" self."syntax-classes-lib" self."syntax-color-lib" self."syntax-macro-lang" self."testing-util-lib" self."tex-table" self."threading-lib" self."tr-immutable" self."type-expander" self."typed-map-lib" self."typed-racket-compatibility" self."typed-racket-doc" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."unstable-list-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [ "alexis-util" "auto-syntax-e" "scope-operations" "scribble-math" "stxparse-info" "subtemplate" "threading" "threading-doc" "version-case" ];
@@ -15869,9 +15919,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable" = self.lib.mkRacketDerivation rec {
   pname = "unstable";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "unstable";
+    src = fetchgit {
+    name = "unstable";
+    url = "git://github.com/racket/unstable.git";
+    rev = "480535837da0cc72112b9edc601885620ba8a55d";
+    sha256 = "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s";
+  };
   };
   racketBuildInputs = [ self."2d-doc" self."2d-lib" self."at-exp-lib" self."automata" self."automata-doc" self."automata-lib" self."base" self."cext-lib" self."class-iop-doc" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-doc" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-doc" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."markparam-doc" self."markparam-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-doc" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-doc" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."ppict" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-doc" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-doc" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-doc" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."staged-slide" self."string-constants-lib" self."syntax-color-doc" self."syntax-color-lib" self."temp-c-doc" self."temp-c-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-doc" self."unix-socket-lib" self."unstable-2d" self."unstable-contract-lib" self."unstable-debug-lib" self."unstable-doc" self."unstable-lib" self."unstable-list-lib" self."unstable-macro-testing-lib" self."unstable-options-lib" self."unstable-parameter-group-lib" self."unstable-pretty-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -15879,9 +15934,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-2d" = self.lib.mkRacketDerivation rec {
   pname = "unstable-2d";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-2d";
+    url = "git://github.com/racket/unstable-2d.git";
+    rev = "abe368e38bf860c607a6b11c212e86519ac8f80e";
+    sha256 = "1vdhglzwzljy03ca4b6h9mdfk6wz89cgyplapiy4xc1ijxh3197l";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."compatibility-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."errortrace-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."planet-lib" self."racket-lib" self."rackunit-lib" self."sandbox-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."source-syntax" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."typed-racket-lib" ];
   circularBuildInputs = [  ];
@@ -15889,9 +15946,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-contract-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-contract-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-contract-lib";
+    url = "git://github.com/racket/unstable-contract-lib.git";
+    rev = "36f4e320c574cef6630ec34ac73f69a2911b86b0";
+    sha256 = "1m8rp3kqfg6lmm96hlaknns0014dvixik6sm4qxjsf80dfvp57wf";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -15899,9 +15958,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-debug-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-debug-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-debug-lib";
+    url = "git://github.com/racket/unstable-debug-lib.git";
+    rev = "f72727898e9a59429eeb419752f5c55926d1a6c4";
+    sha256 = "195bjfbgf42gbrdpay4zscwlq493xpnaik683vzmqms3akdykhxl";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -15909,9 +15970,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-doc" = self.lib.mkRacketDerivation rec {
   pname = "unstable-doc";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "unstable-doc";
+    src = fetchgit {
+    name = "unstable-doc";
+    url = "git://github.com/racket/unstable.git";
+    rev = "480535837da0cc72112b9edc601885620ba8a55d";
+    sha256 = "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s";
+  };
   };
   racketBuildInputs = [ self."2d-doc" self."2d-lib" self."at-exp-lib" self."automata" self."automata-doc" self."automata-lib" self."base" self."cext-lib" self."class-iop-doc" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-doc" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-doc" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."markparam-doc" self."markparam-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-doc" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-doc" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."ppict" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-doc" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-doc" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-doc" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."staged-slide" self."string-constants-lib" self."syntax-color-doc" self."syntax-color-lib" self."temp-c-doc" self."temp-c-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-doc" self."unix-socket-lib" self."unstable-2d" self."unstable-contract-lib" self."unstable-debug-lib" self."unstable-lib" self."unstable-list-lib" self."unstable-macro-testing-lib" self."unstable-options-lib" self."unstable-parameter-group-lib" self."unstable-pretty-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -15919,9 +15985,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-flonum-doc" = self.lib.mkRacketDerivation rec {
   pname = "unstable-flonum-doc";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "unstable-flonum-doc";
+    src = fetchgit {
+    name = "unstable-flonum-doc";
+    url = "git://github.com/racket/unstable-flonum.git";
+    rev = "7071d9a3ee0ad60f947c0a597ddd4b64bed3d94a";
+    sha256 = "0ll6mqmyi3pisgpnv8ilji90c91d2kzc6bhqiyqqrm8930kymqld";
+  };
   };
   racketBuildInputs = [ self."2d-doc" self."2d-lib" self."at-exp-lib" self."automata" self."automata-doc" self."automata-lib" self."base" self."cext-lib" self."class-iop-doc" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-doc" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-doc" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."markparam-doc" self."markparam-lib" self."math-doc" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-doc" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-doc" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot" self."plot-compat" self."plot-doc" self."plot-gui-lib" self."plot-lib" self."ppict" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-doc" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-doc" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-doc" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."staged-slide" self."string-constants-lib" self."syntax-color-doc" self."syntax-color-lib" self."temp-c-doc" self."temp-c-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-doc" self."unix-socket-lib" self."unstable" self."unstable-2d" self."unstable-contract-lib" self."unstable-debug-lib" self."unstable-doc" self."unstable-flonum-lib" self."unstable-lib" self."unstable-list-lib" self."unstable-macro-testing-lib" self."unstable-options-lib" self."unstable-parameter-group-lib" self."unstable-pretty-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -15929,9 +16000,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-flonum-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-flonum-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "unstable-flonum-lib";
+    src = fetchgit {
+    name = "unstable-flonum-lib";
+    url = "git://github.com/racket/unstable-flonum.git";
+    rev = "7071d9a3ee0ad60f947c0a597ddd4b64bed3d94a";
+    sha256 = "0ll6mqmyi3pisgpnv8ilji90c91d2kzc6bhqiyqqrm8930kymqld";
+  };
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -15939,9 +16015,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-latent-contract-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-latent-contract-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-latent-contract-lib";
+    url = "git://github.com/racket/unstable-latent-contract-lib.git";
+    rev = "3bd435890dae3365abe90fd1b5f7c62837e3801e";
+    sha256 = "0wv0kh6mr97yz16yy3f3zkc7pv1f2jvc41jqs5wlilb7dkqz0csc";
   };
   racketBuildInputs = [ self."at-exp-lib" self."base" self."compatibility-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."errortrace-lib" self."images-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."planet-lib" self."racket-lib" self."rackunit-lib" self."sandbox-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."source-syntax" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."typed-racket-lib" ];
   circularBuildInputs = [  ];
@@ -15949,9 +16027,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "unstable-lib";
+    src = fetchgit {
+    name = "unstable-lib";
+    url = "git://github.com/racket/unstable.git";
+    rev = "480535837da0cc72112b9edc601885620ba8a55d";
+    sha256 = "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."automata-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."markparam-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-doc" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."ppict" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-doc" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."staged-slide" self."string-constants-lib" self."syntax-color-lib" self."temp-c-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."unstable-macro-testing-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -15959,9 +16042,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-list-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-list-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-list-lib";
+    url = "git://github.com/racket/unstable-list-lib.git";
+    rev = "a328c5e663072779f70a42a722d2c3e9f2c430c3";
+    sha256 = "1vjccqyqysbkb45j5nrdgl3i92vzy99g1mh303lr5gh72h6v6b4h";
   };
   racketBuildInputs = [ self."base" self."class-iop-lib" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -15969,9 +16054,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-macro-testing-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-macro-testing-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-macro-testing-lib";
+    url = "git://github.com/racket/unstable-macro-testing-lib.git";
+    rev = "92c7c6d8fb35f17fb74ab4f2ad995f487cca0d96";
+    sha256 = "03x9vl9i2sr4v41wik5zaxljy40dw4srxkbbakskisz8sw25w6q6";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -15979,9 +16066,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-options-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-options-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-options-lib";
+    url = "git://github.com/racket/unstable-options-lib.git";
+    rev = "1063efe9e8f02ecdf8aefd6200d759ba1f0e8d5c";
+    sha256 = "1msq3fqsrqxx93yc1fp7v1wh2bjak19jkkd7i008867hclvw8p5z";
   };
   racketBuildInputs = [ self."base" self."option-contract-lib" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -15989,9 +16078,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-parameter-group-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-parameter-group-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-parameter-group-lib";
+    url = "git://github.com/racket/unstable-parameter-group-lib.git";
+    rev = "30de3acb3487c9c3ed4e8ef664ca18bb9667be09";
+    sha256 = "1bxwkf6j6pkm1j4wx6ypx6qs82mgiq0vc00n50brrh72sf4qdv2w";
   };
   racketBuildInputs = [ self."at-exp-lib" self."base" self."compatibility-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."errortrace-lib" self."images-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."planet-lib" self."racket-lib" self."rackunit-lib" self."sandbox-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."source-syntax" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."typed-racket-lib" ];
   circularBuildInputs = [  ];
@@ -15999,9 +16090,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-pretty-lib" = self.lib.mkRacketDerivation rec {
   pname = "unstable-pretty-lib";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-pretty-lib";
+    url = "git://github.com/racket/unstable-pretty-lib.git";
+    rev = "5d6d24be2b0a9c773ac30a22c870b7817ce9f90a";
+    sha256 = "02nv3l1x0fljqr5isrxf98z25zm3jpjfjiy6827g37vwc7iq6d7r";
   };
   racketBuildInputs = [ self."base" self."racket-lib" ];
   circularBuildInputs = [  ];
@@ -16009,9 +16102,11 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-redex" = self.lib.mkRacketDerivation rec {
   pname = "unstable-redex";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = fetchgit {
+    name = "unstable-redex";
+    url = "git://github.com/racket/unstable-redex.git";
+    rev = "a132a56200d99be9e3cec3928d8580559402beb6";
+    sha256 = "0f45vjk67hc4fcjpxqmpfrmg8qlzvgsnmx801ifyg74v48dw3s2m";
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-doc" self."compatibility-lib" self."compiler-lib" self."data-doc" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-doc" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-doc" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-doc" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."mzscheme-doc" self."net-cookies-lib" self."net-lib" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-doc" self."pict-lib" self."pict-snip-lib" self."plai" self."plai-doc" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."redex-benchmark" self."redex-doc" self."redex-examples" self."redex-gui-lib" self."redex-lib" self."redex-pict-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-doc" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."string-constants-lib" self."syntax-color-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."web-server-doc" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];
@@ -16019,9 +16114,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   };
   "unstable-test" = self.lib.mkRacketDerivation rec {
   pname = "unstable-test";
-  src = fetchurl {
-    url = "http://racket-packages.s3-us-west-2.amazonaws.com/pkgs/empty.zip";
-    sha1 = "9f098dddde7f217879070816090c1e8e74d49432";
+  src = self.lib.extractPath {
+    path = "unstable-test";
+    src = fetchgit {
+    name = "unstable-test";
+    url = "git://github.com/racket/unstable.git";
+    rev = "480535837da0cc72112b9edc601885620ba8a55d";
+    sha256 = "1l133jg699d8cn4gylv279vcaanzskna40ffdzapvl3fzn8r5v5s";
+  };
   };
   racketBuildInputs = [ self."2d-lib" self."at-exp-lib" self."automata-lib" self."base" self."cext-lib" self."class-iop-lib" self."compatibility+compatibility-doc+data-doc+db-doc+distributed-p..." self."compatibility-lib" self."compiler-lib" self."data-enumerate-lib" self."data-lib" self."db-lib" self."deinprogramm-signature+htdp-lib" self."distributed-places-lib" self."draw-i386-macosx-3" self."draw-lib" self."draw-ppc-macosx-3" self."draw-ttf-x86_64-linux-natipkg" self."draw-win32-i386-3" self."draw-win32-x86_64-3" self."draw-x11-x86_64-linux-natipkg" self."draw-x86_64-linux-natipkg-3" self."draw-x86_64-macosx-3" self."drracket-plugin-lib" self."drracket-tool-lib" self."dynext-lib" self."eli-tester" self."errortrace-lib" self."gui-i386-macosx" self."gui-lib" self."gui-pkg-manager-lib" self."gui-ppc-macosx" self."gui-win32-i386" self."gui-win32-x86_64" self."gui-x86_64-linux-natipkg" self."gui-x86_64-macosx" self."htdp-lib" self."html-lib" self."icons" self."images-gui-lib" self."images-lib" self."macro-debugger-text-lib" self."markparam-lib" self."math-i386-macosx" self."math-lib" self."math-ppc-macosx" self."math-win32-i386" self."math-win32-x86_64" self."math-x86_64-linux-natipkg" self."math-x86_64-macosx" self."net-cookies-lib" self."net-lib" self."net-test+racket-test" self."option-contract-lib" self."parser-tools-lib" self."pconvert-lib" self."pict-doc" self."pict-lib" self."pict-snip-lib" self."plai-lib" self."planet-lib" self."plot-compat" self."plot-gui-lib" self."plot-lib" self."ppict" self."profile-lib" self."r5rs-lib" self."r6rs-lib" self."racket-doc" self."racket-index" self."racket-lib" self."racket-test" self."racket-test-core" self."rackunit-gui" self."rackunit-lib" self."rackunit-typed" self."readline-lib" self."sandbox-lib" self."sasl-lib" self."scheme-lib" self."scribble-html-lib" self."scribble-lib" self."scribble-text-lib" self."serialize-cstruct-lib" self."slideshow-doc" self."slideshow-lib" self."snip-lib" self."source-syntax" self."srfi-lib" self."srfi-lite-lib" self."staged-slide" self."string-constants-lib" self."syntax-color-lib" self."temp-c-lib" self."testing-util-lib" self."tex-table" self."typed-racket-compatibility" self."typed-racket-lib" self."typed-racket-more" self."unix-socket-lib" self."unstable-2d" self."unstable-contract-lib" self."unstable-debug-lib" self."unstable-lib" self."unstable-list-lib" self."unstable-macro-testing-lib" self."unstable-options-lib" self."unstable-parameter-group-lib" self."web-server-lib" self."wxme-lib" self."xrepl-lib" self."zo-lib" ];
   circularBuildInputs = [  ];

--- a/racket2nix
+++ b/racket2nix
@@ -1,8 +1,10 @@
 #! /usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_NAME=${BASH_SOURCE[0]##*/}
 SCRIPT_DIR=$(cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}" && pwd)
 
-exec racket -N "$SCRIPT_NAME" -- "$SCRIPT_DIR/nix/racket2nix.rkt" ${1+"$@"}
+racket=$(nix-build --no-out-link "$SCRIPT_DIR" -A racket)
+
+exec $racket/bin/racket -N "$SCRIPT_NAME" -- "$SCRIPT_DIR/nix/racket2nix.rkt" "$@"

--- a/release.nix
+++ b/release.nix
@@ -41,7 +41,7 @@ in
     '';
     racket2nix-overlay-updated = runCommand "racket2nix-overlay-updated" {
       src = builtins.filterSource (path: type: type != "symlink") <racket2nix>;
-      buildInputs = builtins.attrValues { inherit bash cacert coreutils diffutils gnused nix racket; };
+      buildInputs = builtins.attrValues { inherit bash cacert coreutils diffutils gnused nix racket2nix; };
       preferLocalBuild = true;
       allowSubstitutes = false;
     } ''
@@ -49,7 +49,7 @@ in
       cp -a $src src
       chmod -R a+w src
       cd src
-      bash ./update-racket2nix-overlay.sh
+      bash ./update-racket2nix-overlay.sh --inside-nix-derivation
       if ! diff -Nur ./ $src | tee $out; then
         echo
         echo ERROR: Your tree is out of date. Please run ./update-racket2nix-overlay.sh before commit.

--- a/update-catalog.sh
+++ b/update-catalog.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -p bash racket-minimal nix-prefetch-git -i bash
+#! nix-shell -p bash nix-prefetch-git -i bash
 
 set -e
 set -u

--- a/update-racket-packages.sh
+++ b/update-racket-packages.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell --pure -p bash cacert coreutils nix racket-minimal -i bash
+#! nix-shell --pure -p bash cacert coreutils nix -i bash
 
 set -e
 set -u

--- a/update-racket2nix-overlay.sh
+++ b/update-racket2nix-overlay.sh
@@ -1,14 +1,20 @@
 #! /usr/bin/env nix-shell
-#! nix-shell --pure -p bash cacert gnused nix racket-minimal -i bash
+#! nix-shell --pure -p bash cacert gnused nix -i bash
 
-set -euo pipefail
+set -eu
 
 SCRIPT_NAME=${BASH_SOURCE[0]##*/}
 cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}"
 
 OUTPUT_FILE=build-racket-racket2nix-overlay.nix
 
-bash ./racket2nix --thin ./nix | 
+if [[ $1 == --inside-nix-derivation ]]; then
+  racket2nix=racket2nix
+else
+  racket2nix=./racket2nix
+fi
+
+$racket2nix --thin ./nix |
   sed -e 's,src =.*,src = ./nix;,p' -e '/src =/,/}/d' \
   > $OUTPUT_FILE.new
 mv $OUTPUT_FILE{.new,}


### PR DESCRIPTION

This breaks all-checked-packages on Racket 7.2.

Solution: Add lookup.

 * Bootstrap nixpkgs without <nixpkgs>, so nix-build can be called from
   nix-shell --pure scripts.
 * Make ./racket2nix use the pinned nixpkgs, so the version is accurate.
 * Lookup package source by racket version.

Closes #94