### PR TITLE
Problem: find-relevant-directories broken

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -216,6 +216,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     PATH=$env/bin:$PATH
     export PLT_COMPILED_FILE_CHECK=exists
 
+    ${raco} setup --no-docs --no-install --no-launcher --no-post-install --no-zo
+
     # install and link us
     install_names=""
     for install_info in ./*/info.rkt; do

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -195,6 +195,8 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     PATH=$env/bin:$PATH
     export PLT_COMPILED_FILE_CHECK=exists
 
+    ${raco} setup --no-docs --no-install --no-launcher --no-post-install --no-zo
+
     # install and link us
     install_names=""
     for install_info in ./*/info.rkt; do


### PR DESCRIPTION
To reproduce:

    $ nix-build --no-out-link --argstr package errortrace-test -A env |
        xargs bash -c '/bin/racket -N raco -l- raco test --help' _
    [ . . . ]
    raco: Unrecognized command: test
    [ . . . ]

Solution: Run raco setup after setting up the environment.

The reason we weren't doing it was because it takes some time, I was
worried it might case recompilation errors in the dependencies, etc.

In fact, there are write attempts when processing the info-domains, but
their failures result in warnings only.

The crucial bit `setup` does is the `updating info-domain tables` bit.
We try to do as little as possible apart from that.

After:

    $ nix-build --no-out-link --argstr package errortrace-test -A env |
        xargs bash -c '/bin/racket -N raco -l- raco test --help' _
    [ . . . ]
    raco test [ <option> ... ] [<file-or-directory-or-collects-or-pkgs>] ...
    [ . . . ]

Closes #78