### PR TITLE
Problem: integration-tests broken

### DIFF
--- a/integration-tests/default.nix
+++ b/integration-tests/default.nix
@@ -80,8 +80,7 @@ packages = lib.mapAttrs nameDepsToDrv deps;
 fix-srcs = drvs: drvs.extend (self: super: (builtins.listToAttrs (map (name: {
   inherit name;
   value = if super.${name} ? pname && packages ? ${super.${name}.pname}
-          then super.${name}.overrideAttrs (_: rec { src = packages.${super.${name}.pname};
-                                                     srcs = [ src ]; })
+          then super.${name}.overrideRacketDerivation (_: { src = packages.${super.${name}.pname}; })
           else super.${name};
 }) (builtins.attrNames super))));
 


### PR DESCRIPTION
Since the 'fix' in 627a958b #273 the integration-test packages have
been confused about what to build, e.g. 'a' is part of a cycle, but
still tries to build from its own source.

    $ ./release.sh -A tests.light-tests
    [ . . . ]
      for package: ./a
      missing packages:
       base
       b
    [ . . . ]

Solution: Override with overrideRacketDerivation.

Fudging with overrideAttrs upset some internal assumption. There is
work to do here on the derivation hygiene, for sure.

The error went undetected because of a bug in ./release.sh
(the -A tests.light-tests is required for the test to run).
Separate PR incoming.