### PR TITLE
 Problem: ./release.sh and Travis are doing far too little

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ os:
  - osx
 script:
  - sudo env NIX_PATH=$NIX_PATH $(which nix-shell) ./support/utils/setup-hydra.fractalide.com.sh
+ - nix-instantiate --add-root $PWD/nixpkgs/result.drv --indirect ./nixpkgs | xargs readlink -e
+ - nix-build --out-link $PWD/nixpkgs/result ./nixpkgs
  - ./support/utils/nix-build-travis-fold.sh -I racket2nix=$PWD release.nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ os:
  - osx
 script:
  - sudo env NIX_PATH=$NIX_PATH $(which nix-shell) ./support/utils/setup-hydra.fractalide.com.sh
- - nix-instantiate --add-root $PWD/nixpkgs/result.drv --indirect ./nixpkgs | xargs readlink -e
+ - nix-instantiate --add-root $PWD/nixpkgs/result.drv --indirect ./nixpkgs | xargs readlink
  - nix-build --out-link $PWD/nixpkgs/result ./nixpkgs
  - ./support/utils/nix-build-travis-fold.sh -I racket2nix=$PWD release.nix

--- a/release.sh
+++ b/release.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 cd "${BASH_SOURCE[0]%/*}"
 
-nix-instantiate --add-root ./nixpkgs/result.drv --indirect ./nixpkgs | xargs readlink -e
+nix-instantiate --add-root ./nixpkgs/result.drv --indirect ./nixpkgs | xargs readlink
 nix-build --no-out-link ./nixpkgs  # So that nix-build-travis-fold can evaluate release.nix
 ./support/utils/nix-build-travis-fold.sh -I racket2nix="$(pwd | xargs readlink -e)" --no-out-link release.nix "$@" |&
   sed -e 's/travis_.*\r//'

--- a/release.sh
+++ b/release.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 
 cd "${BASH_SOURCE[0]%/*}"
 
+nix-build --no-out-link ./nixpkgs  # So that nix-build-travis-fold can evaluate release.nix
 ./support/utils/nix-build-travis-fold.sh -I racket2nix="$(pwd | xargs readlink -e)" --no-out-link release.nix "$@" |&
   sed -e 's/travis_.*\r//'

--- a/release.sh
+++ b/release.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 cd "${BASH_SOURCE[0]%/*}"
 
+nix-instantiate --add-root ./nixpkgs/result.drv --indirect ./nixpkgs | xargs readlink -e
 nix-build --no-out-link ./nixpkgs  # So that nix-build-travis-fold can evaluate release.nix
 ./support/utils/nix-build-travis-fold.sh -I racket2nix="$(pwd | xargs readlink -e)" --no-out-link release.nix "$@" |&
   sed -e 's/travis_.*\r//'

--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -14,6 +14,7 @@ function main() {
     while read attr; do
       # attr may be optional
       fileHasAttr "$file" $attr &&
+        echo >&2 "$attr..." &&
         build "$@" -A $attr
     done <<< "$order"
   else
@@ -85,8 +86,8 @@ function fileHasAttr() {
   local filename=$1
   local attr=$2
 
-  (( $(nix-instantiate --eval --argstr attr "$attr" --arg filename "$filename" \
-       -E '{filename, attr}: if builtins.hasAttr attr (import filename { isTravis = true; }) then 1 else 0' ||
+  (( $(nix-instantiate --eval --arg filename "$filename" \
+       -E "{filename}: if (import filename { isTravis = true; }) ? $attr then 1 else 0" ||
        true) ))
 }
 

--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -9,12 +9,15 @@ function main() {
   local file=$(nixizeFilename "$maybe_file")
 
   if [[ -n $file ]] && fileHasAttr "$file" travisOrder; then
+    local order=$(getOrder "$file")
+    echo >&2 "Building $(echo $order)"
     while read attr; do
       # attr may be optional
       fileHasAttr "$file" $attr &&
         build "$@" -A $attr
-    done < <(getOrder "$file")
+    done <<< "$order"
   else
+    echo >&2 "Building $*"
     build "$@"
   fi
 }
@@ -83,14 +86,15 @@ function fileHasAttr() {
   local attr=$2
 
   (( $(nix-instantiate --eval --argstr attr "$attr" --arg filename "$filename" \
-       -E '{filename, attr}: if builtins.hasAttr attr (import filename) then 1 else 0' 2>/dev/null || true) ))
+       -E '{filename, attr}: if builtins.hasAttr attr (import filename { isTravis = true; }) then 1 else 0' ||
+       true) ))
 }
 
 function getOrder() {
   # This is not overkill, this is the simplest way to parse a nix array -- let nix parse
   local filename=$1
 
-  out=$(nix-build -E '(import <nixpkgs> {}).runCommand "order" { inherit (import '$filename') travisOrder; }
+  out=$(nix-build -E '(import <nixpkgs> {}).runCommand "order" { inherit (import '$filename' { isTravis = true; }) travisOrder; }
                       "for item in $travisOrder; do echo $item >> $out; done"' 2>/dev/null || true)
 
   [[ -z $out ]] && return


### PR DESCRIPTION

getOrder has been failing for a year, since 0dc6347 #141

In ./release.sh and Travis we fall back to only building the top-level
attributes in release.nix.

Solution: Feed release.nix the isTravis argument when evaluating.

 * Fail louder and be more verbose about what is actually being built.
 * Correctly detect tests.in.sub.attrs.