### PR TITLE
Problem: The most important test response does not come first

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -59,7 +59,8 @@ in
     latest-nixpkgs = genJobs (pkgs { pkgs = import <nixpkgs> {}; });
   } // lib.optionalAttrs isTravis {
     stage0-nix-prerequisites = (pkgs {}).racket2nix-stage0.buildInputs;
-    travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix" "tests.light-tests"
+    travisOrder = [ "pkgs-all" "stage0-nix-prerequisites" "racket2nix"
                     "racket-packages-updated" "racket2nix-overlay-updated"
+                    "tests.light-tests"
                     "racket-full.racket2nix" "api.override-racket-derivation" ];
   }) {}


### PR DESCRIPTION
Solution: Fail faster if the PR failed to update generated files.

Put -updated checks before the light-tests. If generated files are not
updated, the other tests mean nothing.