### PR TITLE
 Problem: installCheck: test+testEnv in the store

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -188,7 +188,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
   srcs = [ src ] ++ attrs.extraSrcs or (map (input: input.src) reverseCircularBuildInputs);
   doInstallCheck = attrs.doInstallCheck or false;
   inherit racket;
-  outputs = [ "out" "env" ] ++ lib.optionals doInstallCheck [ "test" "testEnv" ];
+  outputs = [ "out" "env" ];
 
   PLT_COMPILED_FILE_CHECK = "exists";
 
@@ -327,13 +327,14 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     testConfigBuildInputsStr = lib.concatStringsSep " " (map (drv: drv.env) testConfigBuildInputs);
   in ''
     runHook preInstallCheck
+    export testEnv=$(mktemp -d --tmpdir XXXXXX-$pname-testEnv)
     makeRacket $testEnv $racket $env ${testConfigBuildInputsStr}
     setupRacket $testEnv
 
     ${findutils}/bin/xargs -I {} -0 -n 1 -P ''${NIX_BUILD_CORES:-1} bash -c '
       set -eu
       testpath=''${1#*/share/racket/pkgs/}
-      logdir="$test/log/''${testpath%/*}"
+      logdir="$testEnv/log/''${testpath%/*}"
       mkdir -p "$logdir"
       timeout 60 ${time}/bin/time -f "%e s $testpath" $testEnv/bin/raco test -q "$1" \
         &> >(grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" | tee "$logdir/''${1##*/}")

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -311,15 +311,15 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
     testConfigBuildInputsStr = lib.concatStringsSep " " (map (drv: drv.env) testConfigBuildInputs);
   in ''
     runHook preInstallCheck
-    mkdir -p $testEnv/etc/racket $testEnv/share
-    racket ${self.lib.makeConfigRktd} $testEnv ${racket} $env ${testConfigBuildInputsStr} > $testEnv/etc/racket/config.rktd
-    ln -s ${self.compiler-lib.env}/share/racket $testEnv/share/racket
+    makeRacket $testEnv $racket $env ${testConfigBuildInputsStr}
+    setupRacket $testEnv
+
     ${findutils}/bin/xargs -I {} -0 -n 1 -P ''${NIX_BUILD_CORES:-1} bash -c '
       set -eu
       testpath=''${1#*/share/racket/pkgs/}
       logdir="$test/log/''${testpath%/*}"
       mkdir -p "$logdir"
-      timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" \
+      timeout 60 ${time}/bin/time -f "%e s $testpath" $testEnv/bin/raco test -q "$1" \
         &> >(grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" | tee "$logdir/''${1##*/}")
     ' {} {} < <(runHook installCheckFileFinder)
     runHook postInstallCheck


### PR DESCRIPTION


These were put in the store during development for troubleshooting.

 * They use up space until collected. This is of particular interest
   for Travis runs.
 * Actually when you want them the most is when a test failed, and
   that's when the store *won't* be updated.

Solution: Put test artifacts in a temp directory instead.

 * This may improve performance, if tmp is on tmpfs.
 * When a test fails, look in the saved build directory for the
   per-module test results.

Refactor: Use makeRacket for env setup.

