### PR TITLE
Problem: installCheck: dep resolution not DRY

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -322,8 +322,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
 
   installCheckFileFinder = ''find "$env"/share/racket/pkgs/"$pname" -name '*.rkt' -print0'';
   installCheckPhase = if !doInstallCheck then null else let
-    testConfigBuildInputs = [ self.compiler-lib ] ++ self.compiler-lib.racketConfigBuildInputs ++
-      (builtins.filter (input: !builtins.elem input reverseCircularBuildInputs) racketBuildInputs);
+    testConfigBuildInputs = racketConfigBuildInputs ++ (self.lib.resolveThinInputs [ self.compiler-lib ]);
     testConfigBuildInputsStr = lib.concatStringsSep " " (map (drv: drv.env) testConfigBuildInputs);
   in ''
     runHook preInstallCheck

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -306,8 +306,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
 
   installCheckFileFinder = ''find "$env"/share/racket/pkgs/"$pname" -name '*.rkt' -print0'';
   installCheckPhase = if !doInstallCheck then null else let
-    testConfigBuildInputs = [ self.compiler-lib ] ++ self.compiler-lib.racketConfigBuildInputs ++
-      (builtins.filter (input: !builtins.elem input reverseCircularBuildInputs) racketBuildInputs);
+    testConfigBuildInputs = racketConfigBuildInputs ++ (self.lib.resolveThinInputs [ self.compiler-lib ]);
     testConfigBuildInputsStr = lib.concatStringsSep " " (map (drv: drv.env) testConfigBuildInputs);
   in ''
     runHook preInstallCheck


### PR DESCRIPTION
 * We are looking inside compiler-lib's dependencies.
 * We are reimplementing racketConfigBuildInputs.

Solution: Use resolveThinInputs and racketConfigBuildInputs