### PR TITLE
Problem: installCheck: Error output can be confusing

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -337,7 +337,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
       mkdir -p "$logdir"
       timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" \
         &> >(grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" | tee "$logdir/''${1##*/}")
-    ' {} {} < <(runHook installCheckFileFinder)
+    ' 'xargs raco test {}' {} < <(runHook installCheckFileFinder)
     runHook postInstallCheck
   '';
 } // attrs)) suppliedAttrs; in racketDerivation.overrideAttrs (oldAttrs: {

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -321,7 +321,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
       mkdir -p "$logdir"
       timeout 60 ${time}/bin/time -f "%e s $testpath" racket -G $testEnv/etc/racket -U -l- raco test -q "$1" \
         &> >(grep -v -e "warning: tool .* registered twice" -e "@[(]test-responsible" | tee "$logdir/''${1##*/}")
-    ' {} {} < <(runHook installCheckFileFinder)
+    ' 'xargs raco test {}' {} < <(runHook installCheckFileFinder)
     runHook postInstallCheck
   '';
 } // attrs)) suppliedAttrs; in racketDerivation.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
The bash process running raco test is named as the file it is testing,
so you can get a confusing error message along the lines of:

    .../info.rkt: foo: unbound variable

What would an info.rkt want with a variable? It's bash that is using
the process name to label its error messages.

Solution: Add some context to the process name.