### PR TITLE
Problem: We leave stray raco links in the out output

### DIFF
--- a/nix/racket2nix.rkt
+++ b/nix/racket2nix.rkt
@@ -301,7 +301,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
 
     mkdir -p $out/bin
     for launcher in $lib/bin/*; do
-      if ! [ "''${launcher##*/}" = racket ]; then
+      if ! [[ ''${launcher##*/} = racket || ''${launcher##*/} = raco ]]; then
         ln -s "$launcher" "$out/bin/''${launcher##*/}"
       fi
     done

--- a/racket-packages.nix
+++ b/racket-packages.nix
@@ -285,7 +285,7 @@ lib.mkRacketDerivation = suppliedAttrs: let racketDerivation = lib.makeOverridab
 
     mkdir -p $out/bin
     for launcher in $lib/bin/*; do
-      if ! [ "''${launcher##*/}" = racket ]; then
+      if ! [[ ''${launcher##*/} = racket || ''${launcher##*/} = raco ]]; then
         ln -s "$launcher" "$out/bin/''${launcher##*/}"
       fi
     done


### PR DESCRIPTION
It's only supposed to have launchers created by the application.

If we would install two racket packages with nix-env, their racos
would collide.

Solution: Add raco to the exceptions from the symlinking.