### PR TITLE
Problem: update-racket2nix-overlay: requires parameter

### DIFF
--- a/update-racket2nix-overlay.sh
+++ b/update-racket2nix-overlay.sh
@@ -8,7 +8,7 @@ cd "${BASH_SOURCE[0]%${SCRIPT_NAME}}"
 
 OUTPUT_FILE=build-racket-racket2nix-overlay.nix
 
-if [[ $1 == --inside-nix-derivation ]]; then
+if (( $# > 0 )) && [[ $1 == --inside-nix-derivation ]]; then
   racket2nix=racket2nix
 else
   racket2nix=./racket2nix


### PR DESCRIPTION
Solution: Test that there is a first parameter before accessing it.