### PR TITLE
Problem: bump-release-catalog is not run with pkgs.racket

### DIFF
--- a/bump-release-catalog.sh
+++ b/bump-release-catalog.sh
@@ -13,7 +13,9 @@ version=$(eval echo $(nix-instantiate --eval -E 'with import ./pkgs {}; racket-f
 
 url=https://download.racket-lang.org/releases/$version/catalog/
 hash=$(nix-hash --type sha256 --base32 --flat <(
-  nix-shell -E 'with import ./pkgs {}; [ racket ]' --run "racket -N dump-catalogs nix/dump-catalogs.rkt $url"))
+  nix-shell -E 'with import ./pkgs {}; callPackage ({ mkShell, racket}:
+    mkShell { buildInputs = [ racket ]; }) {}' \
+    --run "racket -N dump-catalogs nix/dump-catalogs.rkt $url"))
 
 cat > release-catalog.json.new <<EOF
 {


### PR DESCRIPTION
Just referring to `[ racket ]` actually never worked.

This means the script has always been running with whatever
`racket` happens to be on `$PATH`, rather than the recently
bumped racket it was supposed to be run with (if called from
`bump-all.sh`).

Solution: Call `nix-shell` with a proper `mkShell` environment.