### PR TITLE
Problem: bump-all calls the removed update-racket-packages.sh

### DIFF
--- a/bump-all.sh
+++ b/bump-all.sh
@@ -9,4 +9,4 @@ cd "${BASH_SOURCE[0]%/*}"
 ./bump-release-catalog.sh
 ./bump-live-catalog.sh
 ./update-catalog.sh
-./update-racket-packages.sh
+nix-shell update.nix -A racket-packages


### PR DESCRIPTION
This file was removed in:
a938f1667fd15b1620d4ef89f734f63c520f830c #308

Solution: Call the racket-packages target in update.nix.